### PR TITLE
prevents Blog/Post/View/RelatedProducts error

### DIFF
--- a/Block/Post/View/RelatedProducts.php
+++ b/Block/Post/View/RelatedProducts.php
@@ -132,6 +132,7 @@ class RelatedProducts extends \Magento\Catalog\Block\Product\AbstractProduct
      */
     public function getIdentities()
     {
-        return [\Magento\Cms\Model\Page::CACHE_TAG . '_relatedproducts_'.$this->getPost()->getId()  ];
+        $post = $this->getPost();
+        return $post ? [ \Magento\Cms\Model\Page::CACHE_TAG . '_relatedproducts_' . $post->getId() ] : [];
     }
 }


### PR DESCRIPTION
"Fatal error: Call to a member function getId() on null in /magefan/module-blog/Block/Post/View/RelatedProducts.php on line 135"

I'm not sure this is completely the correct solution, but without it, the blog index page can't even load. Is it sensible to return no cache tags in this situation?