### PR TITLE
Fix for issue #211

### DIFF
--- a/view/adminhtml/layout/blog_post_edit.xml
+++ b/view/adminhtml/layout/blog_post_edit.xml
@@ -27,13 +27,6 @@
                         <item name="componentType" xsi:type="string">fieldset</item>
                     </argument>
                 </arguments>
-                <block class="Magefan\Blog\Block\Adminhtml\Post\Helper\Form\Gallery\Content" as="content">
-                    <arguments>
-                        <argument name="config" xsi:type="array">
-                            <item name="parentComponent" xsi:type="string">blog_post_form.blog_post_form.block_gallery.block_gallery</item>
-                        </argument>
-                    </arguments>
-                </block>
             </block>
         </referenceContainer>
     </body>


### PR DESCRIPTION
Fixes the following error when editing a blog post:
> main.CRITICAL: The element 'gallery' already has a child with alias 'content' {"exception":"[object] (Magento\Framework\Exception\LocalizedException(code: 0): The element 'gallery' already has a child with alias 'content' at /data/web/magento2/magento/vendor/magento/framework/Data/Structure.php:611)"} []

(The 'content' is already added in `vendor/magefan/module-blog/view/adminhtml/ui_component/blog_post_form.xml`)