### PR TITLE
fix typo issue

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -408,7 +408,7 @@
                 </field>
                 <field id="category_sufix" translate="label comment" type="text" sortOrder="45" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Category URL Suffix</label>
-                    <comment>E.g.: ".html" will make the blog category accessible from mystore.com/{blog_route}/post/post-identifier.html</comment>
+                    <comment>E.g.: ".html" will make the blog category accessible from mystore.com/{blog_route}/category/category-identifier.html</comment>
                 </field>
                 <field id="category_use_categories" translate="label" type="select" sortOrder="46" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Use Parent Category Path for Category URLs</label>


### PR DESCRIPTION
Hello,Magefan.

I found typo issue in system.xml.
I think The category URL suffix is not  '/post/post-identifier.html' but '/category/category-identifier.html' .
Thank you!

kadowaki