### PR TITLE
Update string offset access due to deprecation

### DIFF
--- a/Model/Import/Wordpress.php
+++ b/Model/Import/Wordpress.php
@@ -122,7 +122,7 @@ class Wordpress extends AbstractImport
             }
             */
 
-            if (isset($data['title']) && $data['title']{0} == '?') {
+            if (isset($data['title']) && $data['title'][0] == '?') {
                 /* fix for ???? titles */
                 $data['title'] = $data['identifier'];
             }


### PR DESCRIPTION
In PHP 7.4 array and string offset access using curly braces is deprecated which will cause setup:di:compile to fail.  Magento will hopefully start supporting PHP 7.4 in 2.4.x so this should be adjusted before then.