### PR TITLE
Accommodate for document_root_is_pub

### DIFF
--- a/Model/Sitemap.php
+++ b/Model/Sitemap.php
@@ -115,8 +115,12 @@ class Sitemap extends \Magento\Sitemap\Model\Sitemap
     public function getSitemapPath(): string
     {
         $path = $this->getData('sitemap_path');
-        if ($this->getServerPath()) {
-            return trim($this->getServerPath(), '/') . $path;
+        if ($serverPath = $this->getServerPath()) {
+            if (!$this->_directory->isDirectory($serverPath)) {
+                $serverPath = BP . '/' . $serverPath;
+            }
+
+            return rtrim($serverPath, '/') . $path;
         }
 
         return $path;


### PR DESCRIPTION
When environment setting `directories/document_root_is_pub` is true, Magento's Sitemap model will start with a path including pub. Mageworx' XML Sitemap module always uses paths from the base path. Relative paths as are stored in Mageworx' settings will therefore map to the wrong place. This change produces correct results with `directories/document_root_is_pub` both on & off.

https://devdocs.magento.com/guides/v2.3/config-guide/prod/config-reference-envphp.html#directories
https://devdocs.magento.com/guides/v2.3/install-gde/tutorials/change-docroot-to-pub.html
https://github.com/magento/magento2/blob/2.3.6/app/code/Magento/Sitemap/Model/Sitemap.php#L254

It also seems that this will now always be the pub directory since https://github.com/magento/magento2/commit/26acabe377aff184e4bca257f012080e14817ede