### PR TITLE
Fix widget link translation

### DIFF
--- a/Block/Widget/Link.php
+++ b/Block/Widget/Link.php
@@ -72,9 +72,9 @@ class Link extends AbstractBlock implements \Magento\Widget\Block\BlockInterface
         }
 
         if (!$href) {
-            return $this->escapeHtml($title);
+            return $this->escapeHtml(__($title));
         } else {
-            return '<a href="' . $this->escapeUrl($href) . '" title="' . $this->escapeHtml($anchorText) . '">' . $this->escapeHtml($title) . '</a>';
+            return '<a href="' . $this->escapeUrl($href) . '" title="' . $this->escapeHtml(__($anchorText)) . '">' . $this->escapeHtml(__($title)) . '</a>';
         }
     }
 


### PR DESCRIPTION
The fix allows to use translation for widget link anchor text and title.