### PR TITLE
Fix for setup:upgrade issue Magento 2.4.4

### DIFF
--- a/Api/ManagementInterface.php
+++ b/Api/ManagementInterface.php
@@ -14,8 +14,8 @@ interface ManagementInterface
      * Create new item.
      *
      * @api
-     * @param string $data.
-     * @return string.
+     * @param string $data
+     * @return string
      */
     public function create($data);
 
@@ -23,9 +23,9 @@ interface ManagementInterface
      * Update item by id.
      *
      * @api
-     * @param int $id.
-     * @param string $data.
-     * @return string.
+     * @param int $id
+     * @param string $data
+     * @return string
      */
     public function update($id, $data);
 
@@ -33,8 +33,8 @@ interface ManagementInterface
      * Remove item by id.
      *
      * @api
-     * @param int $id.
-     * @return bool.
+     * @param int $id
+     * @return bool
      */
     public function delete($id);
 
@@ -42,8 +42,8 @@ interface ManagementInterface
      * Get item by id.
      *
      * @api
-     * @param int $id.
-     * @return bool.
+     * @param int $id
+     * @return bool
      */
     public function get($id);
 
@@ -53,7 +53,7 @@ interface ManagementInterface
      * @api
      * @param int $id
      * @param  int $storeId
-     * @return bool.
+     * @return bool
      */
     public function view($id, $storeId);
 


### PR DESCRIPTION
The dots prevent object creation:

```
Type Error occurred when creating object: Magento\Framework\Communication\Config\Data, Argument 2 passed to Magento\Framework\Reflection\TypeProcessor::resolveFullyQualifiedClassName() must be of the type string, null given, called in /Users/frankbokdam/sites/gereedschapbestellen/vendor/magento/framework/Reflection/TypeProcessor.php on line 550
```