### PR TITLE
Allow magefan_blog folder images to be downloaded by get.php

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -147,5 +147,14 @@
                 <max_depth>0</max_depth>
             </top_menu>
         </mfblog>
+        <system>
+            <media_storage_configuration>
+                <allowed_resources>
+                    <media_gallery_image_folders>
+                        <magefan_blog>magefan_blog</magefan_blog>
+                    </media_gallery_image_folders>
+                </allowed_resources>
+            </media_storage_configuration>
+        </system>
     </default>
 </config>


### PR DESCRIPTION
Current, pub/get.php fails to download images from remote storage because the `media/magefan_blog` folder isn't in the allow list. This fixes that.

See also https://devdocs.magento.com/guides/v2.4/ext-best-practices/tutorials/modify-image-library-permissions/#configxml