### PR TITLE
Added support for capitalized tag names

### DIFF
--- a/Model/ResourceModel/Tag.php
+++ b/Model/ResourceModel/Tag.php
@@ -49,7 +49,7 @@ class Tag extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     protected function _beforeSave(\Magento\Framework\Model\AbstractModel $object)
     {
         $object->setTitle(
-            trim(strtolower($object->getTitle()))
+            trim($object->getTitle())
         );
 
         $tag = $object->getCollection()


### PR DESCRIPTION
We'd like to create capitalized tag names as well for our blog posts.   For example AED's shouldn't be given lowercased.
Would it be possible to merge this into the base repository?   Thanks in advance!