### PR TITLE
trim(): Passing null to first parameter of type string is deprecated

### DIFF
--- a/Block/Widget/Link.php
+++ b/Block/Widget/Link.php
@@ -66,7 +66,7 @@ class Link extends AbstractBlock implements \Magento\Widget\Block\BlockInterface
             $title = $model->getTitle();
         }
 
-        $anchorText = trim($this->getData('anchor_text'));
+        $anchorText = $this->getData('anchor_text') ? trim($this->getData('anchor_text')) : '';
         if (!$anchorText) {
             $anchorText = $model->getTitle();
         }
@@ -87,7 +87,7 @@ class Link extends AbstractBlock implements \Magento\Widget\Block\BlockInterface
             $this->model = false;
 
             try {
-                $id = trim($this->getData('entity_id'));
+                $id = $this->getData('entity_id') ? trim($this->getData('entity_id')) : '';
                 if ($id) {
                     $this->model = \Magento\Framework\App\ObjectManager::getInstance()
                         ->get($this->modelRepository['instance'])


### PR DESCRIPTION
This basically adopts the change from https://github.com/magefan/module-blog/commit/347630585318060a03fdaadcdd4162bd2269db42 to the other fields as well. This is required in PHP v8+ for cases where the `anchor_text` property is missing.