### PR TITLE
Update csp_whitelist.xml

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -16,6 +16,7 @@
             <policy id="script-src">
                 <values>
                     <value id="magefan-blog-addthis-buttons" type="host">s7.addthis.com</value>
+                    <value id="lazy-loading-js-inline" type="hash" algorithm="sha256">YmHiQ3j6KIQVPjC0Q1NzBMB6tw2OyiYYFYt1uornYeU=</value>
                 </values>
             </policy>
         </policies>


### PR DESCRIPTION
Added whitelist entry for lazyload-js.phtml. Since Magento 2.4.7 or 2.4.6-p6 the global <script> will be blocked for checkout or payment pages. (Only tmp fix. You might consider integrating the corresponding block via "blog_default.xml" instead of "default.xml" so that the script is not integrated on all pages.)