### PR TITLE
fix Magento2.Legacy.EscapeMethodsOnBlockClass 

### DIFF
--- a/view/frontend/templates/category/subcategory-links.phtml
+++ b/view/frontend/templates/category/subcategory-links.phtml
@@ -22,8 +22,8 @@ $subCategoriesCollection = $block->getSubCategories();
         <ul class="subcategory-links">
             <?php foreach ($subCategoriesCollection as $category) { ?>
                 <li>
-                    <?php $categoryTitle = $block->escapeHtml($category->getTitle()) ?>
-                    <a href="<?= $block->escapeUrl($category->getCategoryUrl()) ?>"
+                    <?php $categoryTitle = $escaper->escapeHtml($category->getTitle()) ?>
+                    <a href="<?= $escaper->escapeUrl($category->getCategoryUrl()) ?>"
                        title="<?= /*@noEscape*/ $categoryTitle ?>">
                         <?= /*@noEscape*/ $categoryTitle ?>
                     </a>

--- a/view/frontend/templates/post/info.phtml
+++ b/view/frontend/templates/post/info.phtml
@@ -20,42 +20,42 @@
     <?php if ($_post->isPublishDateEnabled()) { ?>
         <div class="item post-posed-date">
             <i class="mf-blog-icon mfbi-calendar"></i>
-            <span class="label"><?= $block->escapeHtml(__('Posted:')) ?></span>
-            <span class="value"><?= $block->escapeHtml($_post->getPublishDate()) ?></span>
+            <span class="label"><?= $escaper->escapeHtml(__('Posted:')) ?></span>
+            <span class="value"><?= $escaper->escapeHtml($_post->getPublishDate()) ?></span>
         </div>
     <?php } ?>
     <?php if ($_categoriesCount = $_post->getCategoriesCount()) { ?>
         <div class="item post-categories">
             <i class="mf-blog-icon mfbi-folder"></i>
-            <span class="label"><?= $block->escapeHtml(__('Categories:')) ?></span>
+            <span class="label"><?= $escaper->escapeHtml(__('Categories:')) ?></span>
             <?php $n = 0; ?>
             <?php foreach ($_post->getParentCategories() as $ct) { ?>
                 <?php $n++; ?>
-                <a title="<?= $block->escapeHtml($ct->getTitle()) ?>"
-                   href="<?= $block->escapeUrl($ct->getCategoryUrl()) ?>"
-                ><?= $block->escapeHtml($ct->getTitle()) ?></a><?= /*@noEscape*/ ($n != $_categoriesCount) ? ',' : '' ?>
+                <a title="<?= $escaper->escapeHtml($ct->getTitle()) ?>"
+                   href="<?= $escaper->escapeUrl($ct->getCategoryUrl()) ?>"
+                ><?= $escaper->escapeHtml($ct->getTitle()) ?></a><?= /*@noEscape*/ ($n != $_categoriesCount) ? ',' : '' ?>
             <?php } ?>
         </div>
     <?php } ?>
     <?php if ($block->magefanCommentsEnabled() && $_post->getCommentsCount()) { ?>
         <div class="item post-comments">
             <i class="mf-blog-icon mfbi-comments"></i>
-            <span class="label"><?= $block->escapeHtml(__('Comments:')) ?></span>
-            <a title="<?= $block->escapeHtml($_post->getTitle()) ?>"
-               href="<?= $block->escapeUrl($_post->getPostUrl()) ?>#post-comments"
-            ><?= $block->escapeHtml($_post->getCommentsCount()) ?></a>
+            <span class="label"><?= $escaper->escapeHtml(__('Comments:')) ?></span>
+            <a title="<?= $escaper->escapeHtml($_post->getTitle()) ?>"
+               href="<?= $escaper->escapeUrl($_post->getPostUrl()) ?>#post-comments"
+            ><?= $escaper->escapeHtml($_post->getCommentsCount()) ?></a>
         </div>
     <?php } ?>
     <?php if ($_tagsCount = $_post->getTagsCount()) { ?>
     <div class="item post-tags">
         <div class="mf-blog-icon mfbi-tags"></div>
-        <span class="label"><?= $block->escapeHtml(__('Tags:')) ?></span>
+        <span class="label"><?= $escaper->escapeHtml(__('Tags:')) ?></span>
         <?php $n = 0; ?>
         <?php foreach ($_post->getRelatedTags() as $tag) { ?>
             <?php $n++; ?>
-            <a title="<?= $block->escapeHtml($tag->getTitle()) ?>"
-               href="<?= $block->escapeUrl($tag->getTagUrl()) ?>"
-            ><?= $block->escapeHtml($tag->getTitle()) ?></a><?= ($n != $_tagsCount) ? ',' : '' ?>
+            <a title="<?= $escaper->escapeHtml($tag->getTitle()) ?>"
+               href="<?= $escaper->escapeUrl($tag->getTagUrl()) ?>"
+            ><?= $escaper->escapeHtml($tag->getTitle()) ?></a><?= ($n != $_tagsCount) ? ',' : '' ?>
         <?php } ?>
     </div>
     <?php } ?>
@@ -63,14 +63,14 @@
         <?php if ($_author = $_post->getAuthor()) { ?>
         <div class="item post-author">
                 <i class="mf-blog-icon mfbi-user"></i>
-                <span class="label"><?= $block->escapeHtml(__('Author:')) ?></span>
+                <span class="label"><?= $escaper->escapeHtml(__('Author:')) ?></span>
                 <span class="value">
                 <?php if ($authorPageEnabled = $block->authorPageEnabled()) { ?>
-                <a title="<?= $block->escapeHtml($_author->getTitle()) ?>"
-                   href="<?= $block->escapeUrl($_author->getAuthorUrl()) ?>">
+                <a title="<?= $escaper->escapeHtml($_author->getTitle()) ?>"
+                   href="<?= $escaper->escapeUrl($_author->getAuthorUrl()) ?>">
                 <?php } ?>
 
-                <?= $block->escapeHtml($_author->getTitle()) ?>
+                <?= $escaper->escapeHtml($_author->getTitle()) ?>
 
                 <?php if ($authorPageEnabled) { ?>
                 </a>
@@ -81,15 +81,15 @@
                     $coAuthorsCount = count($coAuthors);
                 ?>
                 <?php if ($coAuthorsCount) { ?>
-                    <?= $block->escapeHtml(__('and')) ?>
+                    <?= $escaper->escapeHtml(__('and')) ?>
                     <?php $z = 0 ?>
-                    <?php foreach($coAuthors as $coAuthor) { ?>
+                    <?php foreach ($coAuthors as $coAuthor) { ?>
                         <?php $z++; ?>
                         <?php if ($block->authorPageEnabled()) { ?>
-                            <a title="<?= $block->escapeHtml($coAuthor->getTitle()) ?>"
-                               href="<?= $block->escapeUrl($coAuthor->getAuthorUrl()) ?>"><?= $block->escapeHtml($coAuthor->getTitle()) ?></a><?php if ($z != $coAuthorsCount) echo ', ' ?>
+                            <a title="<?= $escaper->escapeHtml($coAuthor->getTitle()) ?>"
+                               href="<?= $escaper->escapeUrl($coAuthor->getAuthorUrl()) ?>"><?= $escaper->escapeHtml($coAuthor->getTitle()) ?></a><?php if ($z != $coAuthorsCount) { echo ', '; } ?>
                         <?php } else { ?>
-                            <?= $block->escapeHtml($coAuthor->getTitle()) ?><?php if ($z != $coAuthorsCount) echo ', ' ?>
+                            <?= $escaper->escapeHtml($coAuthor->getTitle()) ?><?php if ($z != $coAuthorsCount) { echo ', '; } ?>
                         <?php } ?>
                     <?php } ?>
                 <?php } ?>
@@ -104,9 +104,9 @@
         <?php if ($viewsCount = $_post->getViewsCount()) { ?>
             <div class="item post-views">
                 <i class="mf-blog-icon mfbi-views"></i>
-                <span class="label"><?= $block->escapeHtml(__('Views:')) ?></span>
+                <span class="label"><?= $escaper->escapeHtml(__('Views:')) ?></span>
                 <span class="value">
-                    <?= $block->escapeHtml($viewsCount)?>
+                    <?= $escaper->escapeHtml($viewsCount)?>
                 </span>
             </div>
         <?php } ?>
@@ -116,7 +116,7 @@
     <?php if ($block->readingTimeEnabled() && $_post->getReadingTime()) { ?>
         <div class="item post-reading-time">
             <i class="mf-blog-icon mfbi-reading-time"></i>
-            <span class="value"><?= $block->escapeHtml($_post->getReadingTime()) . ' ' . __('min read') ?></span>
+            <span class="value"><?= $escaper->escapeHtml($_post->getReadingTime()) . ' ' . __('min read') ?></span>
         </div>
     <?php } ?>
 

--- a/view/frontend/templates/post/links.phtml
+++ b/view/frontend/templates/post/links.phtml
@@ -19,7 +19,7 @@
 <?php if (!$postCollection->count()) { ?>
     <div class="message info empty">
         <div>
-            <?= $block->escapeHtml(__('We can\'t find posts matching the selection.')) ?>
+            <?= $escaper->escapeHtml(__('We can\'t find posts matching the selection.')) ?>
         </div>
     </div>
 <?php } else { ?>
@@ -30,9 +30,9 @@
             <?php foreach ($postCollection as $post): ?>
                 <li>
                     <?php $postTitle = $post->getTitle() ?>
-                    <a href="<?= $block->escapeUrl($post->getPostUrl()) ?>"
-                       title="<?= $block->escapeHtml($postTitle) ?>">
-                        <?= $block->escapeHtml($postTitle) ?>
+                    <a href="<?= $escaper->escapeUrl($post->getPostUrl()) ?>"
+                       title="<?= $escaper->escapeHtml($postTitle) ?>">
+                        <?= $escaper->escapeHtml($postTitle) ?>
                     </a>
                 </li>
             <?php endforeach; ?>

--- a/view/frontend/templates/post/list-modern.phtml
+++ b/view/frontend/templates/post/list-modern.phtml
@@ -21,7 +21,7 @@ $imageHelper = $this->helper(\Magefan\Blog\Helper\Image::class);
 <?php if (!$_postCollection->count()): ?>
     <div class="message info empty">
         <div>
-            <?= $block->escapeHtml(__('We can\'t find posts matching the selection.')) ?>
+            <?= $escaper->escapeHtml(__('We can\'t find posts matching the selection.')) ?>
         </div>
     </div>
 <?php else: ?>
@@ -33,8 +33,8 @@ $imageHelper = $this->helper(\Magefan\Blog\Helper\Image::class);
         <ol class="post-list modern">
             <?php foreach ($_postCollection as $_post): ?>
                 <?php
-                    $_postUrl = $block->escapeUrl($_post->getPostUrl());
-                    $_postName = $block->escapeHtml($_post->getTitle());
+                    $_postUrl = $escaper->escapeUrl($_post->getPostUrl());
+                    $_postName = $escaper->escapeHtml($_post->getTitle());
                 ?>
                 <li class="post-item post-holder post-holder-<?= (int)$_post->getId() ?>">
 
@@ -58,7 +58,7 @@ $imageHelper = $this->helper(\Magefan\Blog\Helper\Image::class);
                                             $featuredImgAlt = $_postName;
                                         }
                                         ?>
-                                        <div class="animation-type-zoom bg-img mfblogunveil" data-original="<?= $block->escapeHtml($featuredImage) ?>"></div>
+                                        <div class="animation-type-zoom bg-img mfblogunveil" data-original="<?= $escaper->escapeHtml($featuredImage) ?>"></div>
                                         <?php /* <img class="" src="<?= $block->escapeHtml($featuredImage) ?>" alt=""> */ ?>
                                     <?php } ?>
                                 </a>
@@ -67,9 +67,9 @@ $imageHelper = $this->helper(\Magefan\Blog\Helper\Image::class);
                                 <?php if ($_categoriesCount = $_post->getCategoriesCount()) { ?>
                                     <span class="post-category">
                                         <?php foreach ($_post->getParentCategories() as $ct) { ?>
-                                            <a class="category-name" href="<?= $block->escapeUrl($ct->getCategoryUrl()) ?>"
-                                               title="<?= $block->escapeHtml($ct->getTitle()) ?>">
-                                                <?= $block->escapeHtml($ct->getTitle()) ?>
+                                            <a class="category-name" href="<?= $escaper->escapeUrl($ct->getCategoryUrl()) ?>"
+                                               title="<?= $escaper->escapeHtml($ct->getTitle()) ?>">
+                                                <?= $escaper->escapeHtml($ct->getTitle()) ?>
                                             </a>
                                         <?php } ?>
                                     </span>
@@ -94,11 +94,11 @@ $imageHelper = $this->helper(\Magefan\Blog\Helper\Image::class);
                                     <?php if ($_author = $_post->getAuthor()) { ?>
                                         <span class="post-author-name">
                                             <?php if ($block->authorPageEnabled()) { ?>
-                                                <a title="<?= $block->escapeHtml($_author->getTitle()) ?>"
-                                                   href="<?= $block->escapeUrl($_author->getAuthorUrl()) ?>"><?= $block->escapeHtml($_author->getTitle()) ?>
+                                                <a title="<?= $escaper->escapeHtml($_author->getTitle()) ?>"
+                                                   href="<?= $escaper->escapeUrl($_author->getAuthorUrl()) ?>"><?= $escaper->escapeHtml($_author->getTitle()) ?>
                                                 </a>
                                             <?php } else { ?>
-                                                <?= $block->escapeHtml($_author->getTitle()) ?>
+                                                <?= $escaper->escapeHtml($_author->getTitle()) ?>
                                             <?php } ?>
 
                                             <?php
@@ -106,15 +106,15 @@ $imageHelper = $this->helper(\Magefan\Blog\Helper\Image::class);
                                             $coAuthorsCount = count($coAuthors);
                                             ?>
                                             <?php if ($coAuthorsCount) { ?>
-                                                <?= $block->escapeHtml(__('and')) ?>
+                                                <?= $escaper->escapeHtml(__('and')) ?>
                                                 <?php $z = 0 ?>
-                                                <?php foreach($coAuthors as $coAuthor) { ?>
+                                                <?php foreach ($coAuthors as $coAuthor) { ?>
                                                     <?php $z++; ?>
                                                     <?php if ($block->authorPageEnabled()) { ?>
-                                                        <a title="<?= $block->escapeHtml($coAuthor->getTitle()) ?>"
-                                                           href="<?= $block->escapeUrl($coAuthor->getAuthorUrl()) ?>"><?= $block->escapeHtml($coAuthor->getTitle()) ?></a><?php if ($z != $coAuthorsCount) echo ', ' ?>
+                                                        <a title="<?= $escaper->escapeHtml($coAuthor->getTitle()) ?>"
+                                                           href="<?= $escaper->escapeUrl($coAuthor->getAuthorUrl()) ?>"><?= $escaper->escapeHtml($coAuthor->getTitle()) ?></a><?php if ($z != $coAuthorsCount) { echo ', '; } ?>
                                                     <?php } else { ?>
-                                                        <?= $block->escapeHtml($coAuthor->getTitle()) ?><?php if ($z != $coAuthorsCount) echo ', ' ?>
+                                                        <?= $escaper->escapeHtml($coAuthor->getTitle()) ?><?php if ($z != $coAuthorsCount) { echo ', '; } ?>
                                                     <?php } ?>
                                                 <?php } ?>
                                             <?php } ?>
@@ -125,14 +125,14 @@ $imageHelper = $this->helper(\Magefan\Blog\Helper\Image::class);
 
                                 <!-- post date -->
                                 <?php if ($_post->isPublishDateEnabled()) { ?>
-                                    <span class="post-date"><?= $block->escapeHtml($_post->getPublishDate()) ?></span>
+                                    <span class="post-date"><?= $escaper->escapeHtml($_post->getPublishDate()) ?></span>
                                 <?php } ?>
 
                                 <!-- post view -->
                                 <?php if ($block->viewsCountEnabled()) { ?>
                                     <?php if ($viewsCount = $_post->getViewsCount()) { ?>
                                         <span class="post-view float-right d-none d-md-block">
-                                            <?= $block->escapeHtml($viewsCount)?>
+                                            <?= $escaper->escapeHtml($viewsCount)?>
                                         </span>
                                     <?php } ?>
                                 <?php } ?>
@@ -146,7 +146,7 @@ $imageHelper = $this->helper(\Magefan\Blog\Helper\Image::class);
                             <!-- read more -->
                             <div class="post-read-more">
                                 <a class="action primary" href="<?= /*@noEscape*/ $_postUrl ?>" title="<?= /*@noEscape*/ $_postName ?>">
-                                    <?= $block->escapeHtml(__('Read more')) ?>
+                                    <?= $escaper->escapeHtml(__('Read more')) ?>
                                 </a>
                             </div>
                         </div>

--- a/view/frontend/templates/post/list.phtml
+++ b/view/frontend/templates/post/list.phtml
@@ -19,7 +19,7 @@ $_postCollection = $block->getPostCollection();
 <?php if (!$_postCollection->count()): ?>
     <div class="message info empty">
         <div>
-            <?= $block->escapeHtml(__('We can\'t find posts matching the selection.')) ?>
+            <?= $escaper->escapeHtml(__('We can\'t find posts matching the selection.')) ?>
         </div>
     </div>
 <?php else: ?>

--- a/view/frontend/templates/post/list/item.phtml
+++ b/view/frontend/templates/post/list/item.phtml
@@ -15,8 +15,8 @@
 ?>
 <?php
 $_post = $block->getPost();
-$_postUrl = $block->escapeUrl($_post->getPostUrl());
-$_postName = $block->escapeHtml($_post->getTitle());
+$_postUrl = $escaper->escapeUrl($_post->getPostUrl());
+$_postName = $escaper->escapeHtml($_post->getTitle());
 ?>
 <li class="post-holder post-holder-<?= (int)$_post->getId() ?>">
     <div class="post-header">
@@ -29,21 +29,21 @@ $_postName = $block->escapeHtml($_post->getTitle());
                 </a>
             </h2>
 
-            <?php if ($block->displayAddThisToolbox()) : ?>
+            <?php if ($block->displayAddThisToolbox()): ?>
             <!-- Post Sharing -->
             <div class="post-sharing post-sharing-top old-post-list-item">
                 <div class="share-elements">
                     <div class="icon-wrapper icon-facebook" onclick="mfShareWindowOpen('<?= $_postUrl ?>', 'facebook')">
-                        <div class="icon" title="<?= $block->escapeHtml(__('Share on %1', 'Facebook')) ?>">
+                        <div class="icon" title="<?= $escaper->escapeHtml(__('Share on %1', 'Facebook')) ?>">
                             <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 32 32" version="1.1"  class="at-icon at-icon-facebook" style="fill: #ffffff;">
-                                <title id="at-svg-facebook-1"><?= $block->escapeHtml(__('Share on %1', 'Facebook')) ?></title>
+                                <title id="at-svg-facebook-1"><?= $escaper->escapeHtml(__('Share on %1', 'Facebook')) ?></title>
                                 <g><path d="M22 5.16c-.406-.054-1.806-.16-3.43-.16-3.4 0-5.733 1.825-5.733 5.17v2.882H9v3.913h3.837V27h4.604V16.965h3.823l.587-3.913h-4.41v-2.5c0-1.123.347-1.903 2.198-1.903H22V5.16z" fill-rule="evenodd"></path></g>
                             </svg>
                         </div>
                     </div>
 
                     <div class="icon-wrapper icon-twitter" onclick="mfShareWindowOpen('<?= $_postUrl ?>', 'twitter')">
-                        <div class="icon" title="<?= $block->escapeHtml(__('Share on %1', 'X')) ?>">
+                        <div class="icon" title="<?= $escaper->escapeHtml(__('Share on %1', 'X')) ?>">
                             <?php /*
                             <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 32 32" version="1.1" class="at-icon at-icon-twitter" style="fill: #ffffff;">
                                 <title id="at-svg-twitter-2"><?= $block->escapeHtml(__('Share on %1', 'Twitter')) ?></title>
@@ -51,16 +51,16 @@ $_postName = $block->escapeHtml($_post->getTitle());
                             </svg>
                             */ ?>
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="-4 -4 32 32" width="48" height="48" fill="none">
-                                <title id="at-svg-twitter-2"><?= $block->escapeHtml(__('Share on %1', 'X')) ?></title>
+                                <title id="at-svg-twitter-2"><?= $escaper->escapeHtml(__('Share on %1', 'X')) ?></title>
                                 <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" fill="#ffffff"></path>
                             </svg>
                         </div>
                     </div>
 
                     <div class="icon-wrapper icon-pinterest" onclick="mfShareWindowOpen('<?= $_postUrl ?>', 'pinterest')">
-                        <div class="icon" title="<?= $block->escapeHtml(__('Share on %1', 'Pinterest')) ?>">
+                        <div class="icon" title="<?= $escaper->escapeHtml(__('Share on %1', 'Pinterest')) ?>">
                             <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 32 32" version="1.1" role="img"  class="at-icon at-icon-pinterest" style="fill: #ffffff;">
-                                <title id="at-svg-pinterest_share-1"><?= $block->escapeHtml(__('Share on %1', 'Pinterest')) ?></title>
+                                <title id="at-svg-pinterest_share-1"><?= $escaper->escapeHtml(__('Share on %1', 'Pinterest')) ?></title>
                                 <g><path d="M7 13.252c0 1.81.772 4.45 2.895 5.045.074.014.178.04.252.04.49 0 .772-1.27.772-1.63 0-.428-1.174-1.34-1.174-3.123 0-3.705 3.028-6.33 6.947-6.33 3.37 0 5.863 1.782 5.863 5.058 0 2.446-1.054 7.035-4.468 7.035-1.232 0-2.286-.83-2.286-2.018 0-1.742 1.307-3.43 1.307-5.225 0-1.092-.67-1.977-1.916-1.977-1.692 0-2.732 1.77-2.732 3.165 0 .774.104 1.63.476 2.336-.683 2.736-2.08 6.814-2.08 9.633 0 .87.135 1.728.224 2.6l.134.137.207-.07c2.494-3.178 2.405-3.8 3.533-7.96.61 1.077 2.182 1.658 3.43 1.658 5.254 0 7.614-4.77 7.614-9.067C26 7.987 21.755 5 17.094 5 12.017 5 7 8.15 7 13.252z" fill-rule="evenodd"></path></g>
                             </svg>
                         </div>
@@ -88,8 +88,8 @@ $_postName = $block->escapeHtml($_post->getTitle());
                 <div class="post-ftimg-hld">
                     <a href="<?= /*@noEscape*/ $_postUrl ?>"
                        title="<?= /*@noEscape*/ $_postName ?>">
-                        <img src="<?= $block->escapeUrl($featuredImage) ?>"
-                             alt="<?= $block->escapeHtml($featuredImgAlt) ?>" />
+                        <img src="<?= $escaper->escapeUrl($featuredImage) ?>"
+                             alt="<?= $escaper->escapeHtml($featuredImgAlt) ?>" />
                     </a>
                 </div>
             <?php } ?>
@@ -99,7 +99,7 @@ $_postName = $block->escapeHtml($_post->getTitle());
             <a class="post-read-more"
                href="<?= /*@noEscape*/ $_postUrl ?>"
                title="<?= /*@noEscape*/ $_postName ?>">
-                <?= $block->escapeHtml(__('Read more &#187;')) ?>
+                <?= $escaper->escapeHtml(__('Read more &#187;')) ?>
             </a>
         </div>
     </div>

--- a/view/frontend/templates/post/list/toolbar.phtml
+++ b/view/frontend/templates/post/list/toolbar.phtml
@@ -14,7 +14,7 @@
  */
 ?>
 <?php if ($block->getCollection()->getSize()) { ?>
-    <?php $pagerHtml = trim( $block->getPagerHtml()) ?>
+    <?php $pagerHtml = trim($block->getPagerHtml()) ?>
     <?php if ($pagerHtml) { ?>
         <?php $woj = $block->getWidgetOptionsJson() ?>
         <div class="toolbar toolbar-blog-posts"

--- a/view/frontend/templates/post/list/toolbar/lazyload.phtml
+++ b/view/frontend/templates/post/list/toolbar/lazyload.phtml
@@ -22,12 +22,12 @@
     <div class="mfblog-autoloader"
          data-mage-init='{"<?= /*@noEscape*/ $block->getLazyloadJs() ?>" : <?= /*@noEscape*/ $config ?>}'>
         <button class="mbblog-lazyload-trigger mfblog-hide-onload action primary"
-                title="<?= $block->escapeHtml(__('See more')) ?>"
+                title="<?= $escaper->escapeHtml(__('See more')) ?>"
                 type="button">
-            <span><?= $block->escapeHtml(__('See more')) ?></span>
+            <span><?= $escaper->escapeHtml(__('See more')) ?></span>
         </button>
         <img class="posts-loader mfblog-show-onload"
-             src="<?= $block->escapeUrl($block->getViewFileUrl('images/loader-2.gif')) ?>"
-             alt="<?= $block->escapeHtml(__('Posts loader')) ?>" />
+             src="<?= $escaper->escapeUrl($block->getViewFileUrl('images/loader-2.gif')) ?>"
+             alt="<?= $escaper->escapeHtml(__('Posts loader')) ?>" />
     </div>
 <?php } ?>

--- a/view/frontend/templates/post/view-modern.phtml
+++ b/view/frontend/templates/post/view-modern.phtml
@@ -16,7 +16,7 @@
 <?php
     $_post = $block->getPost();
     $_postUrl = $_post->getPostUrl();
-    $_postName = $block->escapeHtml($_post->getTitle(), null);
+    $_postName = $escaper->escapeHtml($_post->getTitle(), null);
 ?>
 <?= $block->getStyleViewModel()->getStyle('Magefan_Blog::css/bootstrap-4.4.1-custom-min.css') ?>
 <div class="_post-view post-view-modern">
@@ -28,9 +28,9 @@
             <?php if ($_categoriesCount = $_post->getCategoriesCount()) { ?>
                 <div class="post-category mb-4">
                         <?php foreach ($_post->getParentCategories() as $ct) { ?>
-                            <a class="category-name" href="<?= $block->escapeUrl($ct->getCategoryUrl()) ?>"
-                               title="<?= $block->escapeHtml($ct->getTitle()) ?>">
-                                <?= $block->escapeHtml($ct->getTitle()) ?>
+                            <a class="category-name" href="<?= $escaper->escapeUrl($ct->getCategoryUrl()) ?>"
+                               title="<?= $escaper->escapeHtml($ct->getTitle()) ?>">
+                                <?= $escaper->escapeHtml($ct->getTitle()) ?>
                             </a>
                         <?php } ?>
                     </div>
@@ -43,11 +43,11 @@
                     <?php if ($_author = $_post->getAuthor()) { ?>
                         <span class="post-author-name">
                             <?php if ($block->authorPageEnabled()) { ?>
-                                <a title="<?= $block->escapeHtml($_author->getTitle()) ?>"
-                                   href="<?= $block->escapeUrl($_author->getAuthorUrl()) ?>"><?= $block->escapeHtml($_author->getTitle()) ?>
+                                <a title="<?= $escaper->escapeHtml($_author->getTitle()) ?>"
+                                   href="<?= $escaper->escapeUrl($_author->getAuthorUrl()) ?>"><?= $escaper->escapeHtml($_author->getTitle()) ?>
                                 </a>
                             <?php } else { ?>
-                                <?= $block->escapeHtml($_author->getTitle()) ?>
+                                <?= $escaper->escapeHtml($_author->getTitle()) ?>
                             <?php } ?>
 
                             <?php
@@ -55,15 +55,15 @@
                                 $coAuthorsCount = count($coAuthors);
                             ?>
                             <?php if ($coAuthorsCount) { ?>
-                                <?= $block->escapeHtml(__('and')) ?>
+                                <?= $escaper->escapeHtml(__('and')) ?>
                                 <?php $z = 0 ?>
-                                <?php foreach($coAuthors as $coAuthor) { ?>
+                                <?php foreach ($coAuthors as $coAuthor) { ?>
                                     <?php $z++; ?>
                                     <?php if ($block->authorPageEnabled()) { ?>
-                                        <a title="<?= $block->escapeHtml($coAuthor->getTitle()) ?>"
-                                           href="<?= $block->escapeUrl($coAuthor->getAuthorUrl()) ?>"><?= $block->escapeHtml($coAuthor->getTitle()) ?></a><?php if ($z != $coAuthorsCount) echo ', ' ?>
+                                        <a title="<?= $escaper->escapeHtml($coAuthor->getTitle()) ?>"
+                                           href="<?= $escaper->escapeUrl($coAuthor->getAuthorUrl()) ?>"><?= $escaper->escapeHtml($coAuthor->getTitle()) ?></a><?php if ($z != $coAuthorsCount) { echo ', '; } ?>
                                     <?php } else { ?>
-                                        <?= $block->escapeHtml($coAuthor->getTitle()) ?><?php if ($z != $coAuthorsCount) echo ', ' ?>
+                                        <?= $escaper->escapeHtml($coAuthor->getTitle()) ?><?php if ($z != $coAuthorsCount) { echo ', '; } ?>
                                     <?php } ?>
                                 <?php } ?>
                             <?php } ?>
@@ -74,12 +74,12 @@
 
                 <!-- post date -->
                 <?php if ($_post->isPublishDateEnabled()) { ?>
-                    <span class="post-date"><?= $block->escapeHtml($_post->getPublishDate()) ?></span>
+                    <span class="post-date"><?= $escaper->escapeHtml($_post->getPublishDate()) ?></span>
                 <?php } ?>
 
                 <!-- reading time -->
                 <?php if ($block->readingTimeEnabled() && $_post->getReadingTime()) { ?>
-                    <span class="reading-time"><?= ' - ' . $block->escapeHtml($_post->getReadingTime()) . ' ' . __('min read') ?></span>
+                    <span class="reading-time"><?= ' - ' . $escaper->escapeHtml($_post->getReadingTime()) . ' ' . __('min read') ?></span>
                 <?php } ?>
 
                 <!-- post views -->
@@ -87,7 +87,7 @@
                     <?php if ($viewsCount = $_post->getViewsCount()) { ?>
                         <span class="post-views float-right d-none d-md-block">
                             <i class="mf-blog-icon mfbi-views"></i>
-                            <?= $block->escapeHtml($viewsCount)?>
+                            <?= $escaper->escapeHtml($viewsCount)?>
                         </span>
                     <?php } ?>
                 <?php } ?>
@@ -96,9 +96,9 @@
                 <?php if ($block->magefanCommentsEnabled() && $_post->getCommentsCount()) { ?>
                     <span class="post-comments float-right d-none d-md-block">
                         <i class="mf-blog-icon mfbi-comments"></i>
-                        <a title="<?= $block->escapeHtml($_post->getTitle()) ?>"
-                           href="<?= $block->escapeUrl($_post->getPostUrl()) ?>#post-comments"
-                        ><?= $block->escapeHtml($_post->getCommentsCount()) ?></a>
+                        <a title="<?= $escaper->escapeHtml($_post->getTitle()) ?>"
+                           href="<?= $escaper->escapeUrl($_post->getPostUrl()) ?>#post-comments"
+                        ><?= $escaper->escapeHtml($_post->getCommentsCount()) ?></a>
                     </span>
                 <?php } ?>
             </div>
@@ -115,8 +115,8 @@
                         }
                     ?>
                     <div class="post-featured-image">
-                        <img src="<?= $block->escapeUrl($featuredImage) ?>"
-                             alt="<?= $block->escapeHtml($featuredImgAlt) ?>" />
+                        <img src="<?= $escaper->escapeUrl($featuredImage) ?>"
+                             alt="<?= $escaper->escapeHtml($featuredImgAlt) ?>" />
                     </div>
                 <?php } ?>
 
@@ -124,13 +124,13 @@
                 <?php if ($_tagsCount = $_post->getTagsCount()) { ?>
                     <div class="post-tag">
                         <div class="item post-tags">
-                            <div class="post-tag-title"><?= $block->escapeHtml(__('Tags')) ?></div>
+                            <div class="post-tag-title"><?= $escaper->escapeHtml(__('Tags')) ?></div>
                             <?php $n = 0; ?>
                             <?php foreach ($_post->getRelatedTags() as $tag) { ?>
                                 <?php $n++; ?>
-                                <a title="<?= $block->escapeHtml($tag->getTitle()) ?>"
-                                   href="<?= $block->escapeUrl($tag->getTagUrl()) ?>"
-                                ><?= $block->escapeHtml($tag->getTitle()) ?></a>
+                                <a title="<?= $escaper->escapeHtml($tag->getTitle()) ?>"
+                                   href="<?= $escaper->escapeUrl($tag->getTagUrl()) ?>"
+                                ><?= $escaper->escapeHtml($tag->getTitle()) ?></a>
                             <?php } ?>
                         </div>
                     </div>
@@ -146,22 +146,22 @@
 
         <div class="post-bottom">
 
-            <?php if ($block->displayAddThisToolbox()) : ?>
+            <?php if ($block->displayAddThisToolbox()): ?>
             <!-- Post Sharing -->
             <div class="post-sharing post-sharing-bottom">
                 <div class="share-elements">
-                    <div class="icon-wrapper icon-facebook" onclick="mfShareWindowOpen('<?= $block->escapeUrl($_postUrl) ?>', 'facebook')">
-                        <div class="icon" title="<?= $block->escapeHtml(__('Share on %1', 'Facebook')) ?>">
+                    <div class="icon-wrapper icon-facebook" onclick="mfShareWindowOpen('<?= $escaper->escapeUrl($_postUrl) ?>', 'facebook')">
+                        <div class="icon" title="<?= $escaper->escapeHtml(__('Share on %1', 'Facebook')) ?>">
                             <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 32 32" version="1.1"  class="at-icon at-icon-facebook" style="fill: #ffffff;width: 48px;height: 48px;">
-                                <title id="at-svg-facebook-1"><?= $block->escapeHtml(__('Share on %1', 'Facebook')) ?></title>
+                                <title id="at-svg-facebook-1"><?= $escaper->escapeHtml(__('Share on %1', 'Facebook')) ?></title>
                                 <g><path d="M22 5.16c-.406-.054-1.806-.16-3.43-.16-3.4 0-5.733 1.825-5.733 5.17v2.882H9v3.913h3.837V27h4.604V16.965h3.823l.587-3.913h-4.41v-2.5c0-1.123.347-1.903 2.198-1.903H22V5.16z" fill-rule="evenodd"></path></g>
                             </svg>
                         </div>
-                        <div class="label"><?= $block->escapeHtml(__('Share on %1', 'Facebook')) ?></div>
+                        <div class="label"><?= $escaper->escapeHtml(__('Share on %1', 'Facebook')) ?></div>
                     </div>
 
-                    <div class="icon-wrapper icon-twitter" onclick="mfShareWindowOpen('<?= $block->escapeUrl($_postUrl) ?>', 'twitter')" >
-                        <div class="icon" title="<?= $block->escapeHtml(__('Share on %1', 'X')) ?>">
+                    <div class="icon-wrapper icon-twitter" onclick="mfShareWindowOpen('<?= $escaper->escapeUrl($_postUrl) ?>', 'twitter')" >
+                        <div class="icon" title="<?= $escaper->escapeHtml(__('Share on %1', 'X')) ?>">
                             <?php /*
                             <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 32 32" version="1.1" class="at-icon at-icon-twitter" style="fill: #ffffff;width: 48px;height: 48px;">
                                 <title id="at-svg-twitter-2"><?= $block->escapeHtml(__('Share on %1', 'Twitter')) ?></title>
@@ -169,21 +169,21 @@
                             </svg>
                             */ ?>
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="-4 -4 32 32" width="48" height="48" fill="none">
-                                <title id="at-svg-twitter-2"><?= $block->escapeHtml(__('Share on %1', 'X')) ?></title>
+                                <title id="at-svg-twitter-2"><?= $escaper->escapeHtml(__('Share on %1', 'X')) ?></title>
                                 <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" fill="#ffffff"></path>
                             </svg>
                         </div>
-                        <div class="label"><?= $block->escapeHtml(__('Share on %1', 'X')) ?></div>
+                        <div class="label"><?= $escaper->escapeHtml(__('Share on %1', 'X')) ?></div>
                     </div>
 
                     <div class="icon-wrapper icon-pinterest" onclick="mfShareWindowOpen('<?= $_postUrl ?>', 'pinterest')">
-                        <div class="icon" title="<?= $block->escapeHtml(__('Share on %1', 'Pinterest')) ?>">
+                        <div class="icon" title="<?= $escaper->escapeHtml(__('Share on %1', 'Pinterest')) ?>">
                             <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 32 32" version="1.1" role="img"  class="at-icon at-icon-pinterest" style="fill: rgb(255, 255, 255);">
-                                <title id="at-svg-pinterest_share-1"><?= $block->escapeHtml(__('Share on %1', 'Pinterest')) ?></title>
+                                <title id="at-svg-pinterest_share-1"><?= $escaper->escapeHtml(__('Share on %1', 'Pinterest')) ?></title>
                                 <g><path d="M7 13.252c0 1.81.772 4.45 2.895 5.045.074.014.178.04.252.04.49 0 .772-1.27.772-1.63 0-.428-1.174-1.34-1.174-3.123 0-3.705 3.028-6.33 6.947-6.33 3.37 0 5.863 1.782 5.863 5.058 0 2.446-1.054 7.035-4.468 7.035-1.232 0-2.286-.83-2.286-2.018 0-1.742 1.307-3.43 1.307-5.225 0-1.092-.67-1.977-1.916-1.977-1.692 0-2.732 1.77-2.732 3.165 0 .774.104 1.63.476 2.336-.683 2.736-2.08 6.814-2.08 9.633 0 .87.135 1.728.224 2.6l.134.137.207-.07c2.494-3.178 2.405-3.8 3.533-7.96.61 1.077 2.182 1.658 3.43 1.658 5.254 0 7.614-4.77 7.614-9.067C26 7.987 21.755 5 17.094 5 12.017 5 7 8.15 7 13.252z" fill-rule="evenodd"></path></g>
                             </svg>
                         </div>
-                        <div class="label"><?= $block->escapeHtml(__('Share on %1', 'Pinterest')) ?></div>
+                        <div class="label"><?= $escaper->escapeHtml(__('Share on %1', 'Pinterest')) ?></div>
                     </div>
                 </div>
             </div>

--- a/view/frontend/templates/post/view.phtml
+++ b/view/frontend/templates/post/view.phtml
@@ -16,28 +16,28 @@
 <?php
 $_post = $block->getPost();
 $_postUrl = $_post->getPostUrl();
-$_postName = $block->escapeHtml($_post->getTitle(), null);
+$_postName = $escaper->escapeHtml($_post->getTitle(), null);
 ?>
 <div class="post-view">
     <div class="post-holder post-holder-<?= (int)$_post->getId() ?>">
 
-        <?php if ($block->displayAddThisToolbox()) : ?>
+        <?php if ($block->displayAddThisToolbox()): ?>
             <div class="post-header">
 
                 <!-- Post Sharing -->
                 <div class="post-sharing post-sharing-top old-post-view">
                     <div class="share-elements">
-                        <div class="icon-wrapper icon-facebook" onclick="mfShareWindowOpen('<?= $block->escapeUrl($_postUrl) ?>', 'facebook')">
-                            <div class="icon" title="<?= $block->escapeHtml(__('Share on %1', 'Facebook')) ?>">
+                        <div class="icon-wrapper icon-facebook" onclick="mfShareWindowOpen('<?= $escaper->escapeUrl($_postUrl) ?>', 'facebook')">
+                            <div class="icon" title="<?= $escaper->escapeHtml(__('Share on %1', 'Facebook')) ?>">
                                 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 32 32" version="1.1"  class="at-icon at-icon-facebook" style="fill: #ffffff;">
-                                    <title id="at-svg-facebook-1"><?= $block->escapeHtml(__('Share on %1', 'Facebook')) ?></title>
+                                    <title id="at-svg-facebook-1"><?= $escaper->escapeHtml(__('Share on %1', 'Facebook')) ?></title>
                                     <g><path d="M22 5.16c-.406-.054-1.806-.16-3.43-.16-3.4 0-5.733 1.825-5.733 5.17v2.882H9v3.913h3.837V27h4.604V16.965h3.823l.587-3.913h-4.41v-2.5c0-1.123.347-1.903 2.198-1.903H22V5.16z" fill-rule="evenodd"></path></g>
                                 </svg>
                             </div>
                         </div>
 
-                        <div class="icon-wrapper icon-twitter" onclick="mfShareWindowOpen('<?= $block->escapeUrl($_postUrl) ?>', 'twitter')">
-                            <div class="icon" title="<?= $block->escapeHtml(__('Share on %1', 'X')) ?>">
+                        <div class="icon-wrapper icon-twitter" onclick="mfShareWindowOpen('<?= $escaper->escapeUrl($_postUrl) ?>', 'twitter')">
+                            <div class="icon" title="<?= $escaper->escapeHtml(__('Share on %1', 'X')) ?>">
                                 <?php /*
                                 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 32 32" version="1.1" class="at-icon at-icon-twitter" style="fill: #ffffff;">
                                     <title id="at-svg-twitter-2"><?= $block->escapeHtml(__('Share on %1', 'Twitter')) ?></title>
@@ -45,7 +45,7 @@ $_postName = $block->escapeHtml($_post->getTitle(), null);
                                 </svg>
                                 */ ?>
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-4 -4 32 32" width="48" height="48" fill="none">
-                                    <title id="at-svg-twitter-2"><?= $block->escapeHtml(__('Share on %1', 'X')) ?></title>
+                                    <title id="at-svg-twitter-2"><?= $escaper->escapeHtml(__('Share on %1', 'X')) ?></title>
                                     <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" fill="#ffffff"></path>
                                 </svg>
                             </div>
@@ -77,8 +77,8 @@ $_postName = $block->escapeHtml($_post->getTitle(), null);
                     }
                     ?>
                     <div class="post-ftimg-hld">
-                        <img src="<?= $block->escapeUrl($featuredImage) ?>"
-                             alt="<?= $block->escapeHtml($featuredImgAlt) ?>" />
+                        <img src="<?= $escaper->escapeUrl($featuredImage) ?>"
+                             alt="<?= $escaper->escapeHtml($featuredImgAlt) ?>" />
                     </div>
                 <?php } ?>
                 <div class="post-text-hld">

--- a/view/frontend/templates/post/view/comments/disqus.phtml
+++ b/view/frontend/templates/post/view/comments/disqus.phtml
@@ -17,11 +17,11 @@
 <div id="disqus_thread"></div>
 <?php $script = "
     var disqus_config = function () {
-        this.page.url = '" . $block->escapeUrl($block->getPost()->getPostUrl()) . "';
+        this.page.url = '" . $escaper->escapeUrl($block->getPost()->getPostUrl()) . "';
     };
     (function() {
         var d = document, s = d.createElement('script');
-        s.src = '" . $block->escapeHtml('/' . '/' .  $block->getDisqusShortname()) . ".disqus.com/embed.js';
+        s.src = '" . $escaper->escapeHtml('/' . '/' .  $block->getDisqusShortname()) . ".disqus.com/embed.js';
         s.setAttribute('data-timestamp', +new Date());
         (d.head || d.body).appendChild(s);
     })();

--- a/view/frontend/templates/post/view/comments/facebook.phtml
+++ b/view/frontend/templates/post/view/comments/facebook.phtml
@@ -20,15 +20,15 @@
     var js, fjs = d.getElementsByTagName(s)[0];
     if (d.getElementById(id)) return;
     js = d.createElement(s); js.id = id;
-    js.src = '" . $block->escapeJs($block->getFbSdkJsUrl()) . "';
+    js.src = '" . $escaper->escapeJs($block->getFbSdkJsUrl()) . "';
     fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));
 "; ?>
 <?= /* @noEscape */ $mfSecureRenderer->renderTag('script', [], $script, false) ?>
 <div class="post-comments clear">
     <div class="fb-comments"
-         data-href="<?= $block->escapeUrl($block->getPost()->getPostUrl()) ?>"
+         data-href="<?= $escaper->escapeUrl($block->getPost()->getPostUrl()) ?>"
          data-width="100%"
-         data-numposts="<?= $block->escapeHtml($block->getNumberOfComments()) ?>">
+         data-numposts="<?= $escaper->escapeHtml($block->getNumberOfComments()) ?>">
     </div>
 </div>

--- a/view/frontend/templates/post/view/comments/magefan.phtml
+++ b/view/frontend/templates/post/view/comments/magefan.phtml
@@ -22,24 +22,24 @@
 ?>
 <div id="post-comments">
     <div class="c-count">
-        <strong><?= $block->escapeHtml(__('%1 Comment(s)', $block->getPost()->getCommentsCount())) ?></strong>
+        <strong><?= $escaper->escapeHtml(__('%1 Comment(s)', $block->getPost()->getCommentsCount())) ?></strong>
     </div>
     <!-- reply form -->
     <div class="c-reply cf">
         <?php if ($image = $block->getCustomerImage()) { ?>
         <div class="c-img">
-            <img src="<?= $block->escapeUrl($image) ?>" alt="<?= $block->escapeHtml($block->getCustomerName()) ?>">
+            <img src="<?= $escaper->escapeUrl($image) ?>" alt="<?= $escaper->escapeHtml($block->getCustomerName()) ?>">
         </div>
         <?php } ?>
         <div class="c-replyform <?php if ($canPost) {  echo 'no-active'; } ?>">
             <form class="comment-form-blog-recaptcha"
-                  action="<?= $block->escapeUrl($block->getFormUrl()) ?>"
+                  action="<?= $escaper->escapeUrl($block->getFormUrl()) ?>"
                   method="post"
                   data-mage-init='{"validation":{}}'>
                 <?= $block->getBlockHtml('formkey') ?>
                 <input type="hidden" name="post_id" value="<?= (int)($block->getPost()->getId()) ?>" />
                 <textarea name="text"
-                          placeholder="<?= $canPost ? $block->escapeHtml(__('Add a comment...')) : $block->escapeHtml(__('Sign in to add a comment...')) ?>" <?php if (!$canPost) {?>
+                          placeholder="<?= $canPost ? $escaper->escapeHtml(__('Add a comment...')) : $escaper->escapeHtml(__('Sign in to add a comment...')) ?>" <?php if (!$canPost) {?>
                           disabled="disabled"<?php } ?>
                           data-validate="{required:true}"></textarea>
                 <div class="c-btn-hld">
@@ -50,7 +50,7 @@
                             <input type="text"
                                    name="author_nickname"
                                    value=""
-                                   placeholder="<?= $block->escapeHtml(__('Full Name')) ?>"
+                                   placeholder="<?= $escaper->escapeHtml(__('Full Name')) ?>"
                                    class="input-text required-entry"
                                    data-validate="{required:true}"
                                    autocomplete="off"
@@ -61,7 +61,7 @@
                                    name="author_email"
                                    autocomplete="email"
                                    value=""
-                                   placeholder="<?= $block->escapeHtml(__('Email')) ?>"
+                                   placeholder="<?= $escaper->escapeHtml(__('Email')) ?>"
                                    class="input-text"
                                    data-validate="{required:true, 'validate-email':true}"
                                    aria-required="true">
@@ -77,11 +77,11 @@
                     <div id="recaptcha-append-to"><?= $block->getChildHtml('blog.post.comments.magefan.additional'); ?></div>
 
                     <?php if ($canPost) { ?>
-                        <button type="submit"><?= $block->escapeHtml(__('Submit')) ?></button>
+                        <button type="submit"><?= $escaper->escapeHtml(__('Submit')) ?></button>
                     <?php } else { ?>
                         <button type="button"
-                                onclick="window.location='<?= $block->escapeUrl($block->getCustomerUrl()->getLoginUrl()) ?>';">
-                            <?= $block->escapeHtml(__('Sign In')) ?>
+                                onclick="window.location='<?= $escaper->escapeUrl($block->getCustomerUrl()->getLoginUrl()) ?>';">
+                            <?= $escaper->escapeHtml(__('Sign In')) ?>
                         </button>
                     <?php } ?>
 
@@ -104,22 +104,22 @@ if ($commentsCount) {
             <?= $block->getCommentHtml($comment) ?>
         <?php } ?>
         <?php if ($commentsCount > $numberOfCommentsToDisplay) { ?>
-            <a href="#" class="c-allcomments more-comments-action" data-comment="0"><?= $block->escapeHtml(__('Load more comments')) ?></a>
+            <a href="#" class="c-allcomments more-comments-action" data-comment="0"><?= $escaper->escapeHtml(__('Load more comments')) ?></a>
         <?php } ?>
     </div>
 
     <!-- reply comment form -->
     <div id="c-replyform-comment" class="c-replyform c-replyform-comment" style="display:none">
         <form class="reply-form-blog-recaptcha"
-              action="<?= $block->escapeUrl($block->getFormUrl()) ?>"
+              action="<?= $escaper->escapeUrl($block->getFormUrl()) ?>"
               method="post"
               data-mage-init='{"validation":{}}'>
             <?= $block->getBlockHtml('formkey') ?>
-            <input type="hidden" name="post_id" value="<?= $block->escapeHtml($block->getPost()->getId()) ?>" />
+            <input type="hidden" name="post_id" value="<?= $escaper->escapeHtml($block->getPost()->getId()) ?>" />
             <input type="hidden" name="parent_id" value="" />
             <textarea class="refresh-value"
                       name="text"
-                      placeholder="<?= $canPost ? $block->escapeHtml(__('Add a reply...')) : $block->escapeHtml(__('Sign in to add a comment...')) ?>" <?php if (!$canPost) {?>
+                      placeholder="<?= $canPost ? $escaper->escapeHtml(__('Add a reply...')) : $escaper->escapeHtml(__('Sign in to add a comment...')) ?>" <?php if (!$canPost) {?>
                       disabled="disabled"<?php } ?>
                       data-validate="{required:true}"></textarea>
             <div class="c-btn-hld">
@@ -130,7 +130,7 @@ if ($commentsCount) {
                         <input type="text"
                                name="author_nickname"
                                value=""
-                               placeholder="<?= $block->escapeHtml(__('Full Name')) ?>"
+                               placeholder="<?= $escaper->escapeHtml(__('Full Name')) ?>"
                                class="input-text required-entry refresh-value"
                                data-validate="{required:true}"
                                autocomplete="off"
@@ -141,16 +141,16 @@ if ($commentsCount) {
                                name="author_email"
                                autocomplete="email"
                                value=""
-                               placeholder="<?= $block->escapeHtml(__('Email')) ?>"
+                               placeholder="<?= $escaper->escapeHtml(__('Email')) ?>"
                                class="input-text required-entry refresh-value"
                                data-validate="{required:true, 'validate-email':true}"
                                aria-required="true">
                     </div>
                 </div>
                 <?php } ?>
-                <button type="button" class="cancel reply-cancel-action" ><?= $block->escapeHtml(__('Cancel')) ?></button>
+                <button type="button" class="cancel reply-cancel-action" ><?= $escaper->escapeHtml(__('Cancel')) ?></button>
             <?php if ($canPost) { ?>
-                    <button type="submit"><?= $block->escapeHtml(__('Submit')) ?></button>
+                    <button type="submit"><?= $escaper->escapeHtml(__('Submit')) ?></button>
                     <?php if ($block->displayPrivacyPolicyCheckbox()) { ?>
                         <?= $block->getChildBlock('display_privacy_policy_checkbox')->setCommentType('comment')->toHtml(); ?>
                     <?php } ?>
@@ -159,8 +159,8 @@ if ($commentsCount) {
                         <?= $block->getChildBlock('display_privacy_policy_checkbox')->setCommentType('comment')->toHtml(); ?>
                     <?php } ?>
                     <button type="button"
-                            onclick="window.location='<?= $block->escapeUrl($block->getCustomerUrl()->getLoginUrl()) ?>';">
-                        <?= $block->escapeHtml(__('Sign In')) ?>
+                            onclick="window.location='<?= $escaper->escapeUrl($block->getCustomerUrl()->getLoginUrl()) ?>';">
+                        <?= $escaper->escapeHtml(__('Sign In')) ?>
                     </button>
                 <?php } ?>
                 <div class="clearfix"></div>

--- a/view/frontend/templates/post/view/comments/magefan/comment.phtml
+++ b/view/frontend/templates/post/view/comments/magefan/comment.phtml
@@ -21,22 +21,22 @@
     <?php if ($comment->getIsHidden()) { echo 'style="display:none"'; } ?>>
     <?php if ($authorImage = $comment->getAuthorImage()) { ?>
     <div class="c-img">
-        <img src="<?= $block->escapeUrl($authorImage) ?>" alt="<?= $block->escapeHtml($comment->getAuthorName()) ?>">
+        <img src="<?= $escaper->escapeUrl($authorImage) ?>" alt="<?= $escaper->escapeHtml($comment->getAuthorName()) ?>">
     </div>
     <?php } ?>
     <div class="c-post c-post-<?= (int)$comment->getId() ?>" id="c-post-<?= (int)$comment->getId() ?>">
         <div class="p-info">
-            <div class="p-name"><?= $block->escapeHtml($comment->getAuthor()->getNickname()) ?></div>
-            <div class="publish-date"><?php echo $block->escapeHtml($block->getPublishDate()) ?></div>
+            <div class="p-name"><?= $escaper->escapeHtml($comment->getAuthor()->getNickname()) ?></div>
+            <div class="publish-date"><?= $escaper->escapeHtml($block->getPublishDate()) ?></div>
         </div>
 
-        <div class="p-text"><?= /*@noEscape*/ nl2br($block->escapeHtml($comment->getText())) ?></div>
+        <div class="p-text"><?= /*@noEscape*/ nl2br($escaper->escapeHtml($comment->getText())) ?></div>
         <div class="p-actions">
             <a href="#" class="reply-action"
                data-comment="<?= $comment->isReply() ?
                    (int)$comment->getParentId() :
                    (int)$comment->getId() ?>"
-               title="<?= $block->escapeHtml(__('Reply')) ?>"><?= $block->escapeHtml(__('Reply')) ?></a>
+               title="<?= $escaper->escapeHtml(__('Reply')) ?>"><?= $escaper->escapeHtml(__('Reply')) ?></a>
         </div>
         <?php
             $replies = $block->getRepliesCollection();
@@ -55,7 +55,7 @@
 
                 <?php if ($commentsCount > $numberOfCommentsToDisplay) { ?>
                 <div class="c-more more-comments-action" data-comment="<?= (int)$comment->getId() ?>">
-                    <a href="#" ><?= $block->escapeHtml(__('Show more replies in this thread')) ?><i></i></a>
+                    <a href="#" ><?= $escaper->escapeHtml(__('Show more replies in this thread')) ?><i></i></a>
                 </div>
                 <?php } ?>
             </div>

--- a/view/frontend/templates/post/view/comments/privacy_policy_checkbox.phtml
+++ b/view/frontend/templates/post/view/comments/privacy_policy_checkbox.phtml
@@ -14,16 +14,16 @@
            value="1"
            data-validate="{required:true}"
            class="checkbox required-entry"
-           id="<?= $block->escapeHtml($id) ?>"
+           id="<?= $escaper->escapeHtml($id) ?>"
            name="privacy">
     <?php
     $privacyPolicy =
         "<a href=" .
-            $block->escapeHtml($block->getUrl('privacy-policy-cookie-restriction-mode')) .
+            $escaper->escapeHtml($block->getUrl('privacy-policy-cookie-restriction-mode')) .
             " target='_blank' style='text-decoration: underline;'>". __('privacy policy') .
         "</a>";
     ?>
-    <label for="<?= $block->escapeHtml($id) ?>"
+    <label for="<?= $escaper->escapeHtml($id) ?>"
            class="required">
         <?= /*@noEscape*/ __('Yes, I have read the %1 and agree to the processing of my personal data.', $privacyPolicy) ?>
     </label>

--- a/view/frontend/templates/post/view/gallery.phtml
+++ b/view/frontend/templates/post/view/gallery.phtml
@@ -24,9 +24,9 @@
         <?php foreach ($galleryImages as $image) { ?>
             <a class="gallery-image-hld"
                data-fancybox="gallery"
-               href="<?= $block->escapeUrl($image) ?>"
+               href="<?= $escaper->escapeUrl($image) ?>"
                rel="nofollow">
-                <img class="gallery-image" src="<?= $block->escapeUrl($image->resize(200, 133)) ?>" alt="" />
+                <img class="gallery-image" src="<?= $escaper->escapeUrl($image->resize(200, 133)) ?>" alt="" />
             </a>
         <?php } ?>
     </div>
@@ -34,7 +34,7 @@
     require(['jquery', 'domReady!'], function($){
         /* Deferer fancybox css loading */
         $('head').append(
-            $(\"<link rel='stylesheet' href='" . $block->escapeUrl($viewFileUrl) . "' type='text/css' media='screen' />\")
+            $(\"<link rel='stylesheet' href='" . $escaper->escapeUrl($viewFileUrl) . "' type='text/css' media='screen' />\")
         );
         /* Deferer fancybox js loading */
         require(['Magefan_Blog/js/jquery.fancybox.min'], function(){});

--- a/view/frontend/templates/post/view/gallery_porto_fanybox2.phtml
+++ b/view/frontend/templates/post/view/gallery_porto_fanybox2.phtml
@@ -26,9 +26,9 @@
     <div class="post-gallery clearfix">
         <?php foreach ($galleryImages as $image) { ?>
             <a class="gallery-image-hld fancybox-thumb"
-               href="<?= $block->escapeUrl($image) ?>"
+               href="<?= $escaper->escapeUrl($image) ?>"
                rel="fancybox-thumb">
-                <img class="gallery-image" src="<?= $block->escapeUrl($image->resize(200)) ?>" alt="" />
+                <img class="gallery-image" src="<?= $escaper->escapeUrl($image->resize(200)) ?>" alt="" />
             </a>
         <?php } ?>
     </div>

--- a/view/frontend/templates/post/view/nextprev-modern.phtml
+++ b/view/frontend/templates/post/view/nextprev-modern.phtml
@@ -25,10 +25,10 @@
                 <?php if ($prevPost) { ?>
                     <?php $title = $prevPost->getTitle() ?>
                     <a class="nextprev-link prev-link float-left"
-                       href="<?= $block->escapeUrl($prevPost->getPostUrl()) ?>"
-                       title="<?= $block->escapeHtml(__('Read %1', $title)) ?>">
-                        <span class="text-left"><?= $block->escapeHtml(__('Previous')) ?></span>
-                        <?= $block->escapeHtml($title) ?>
+                       href="<?= $escaper->escapeUrl($prevPost->getPostUrl()) ?>"
+                       title="<?= $escaper->escapeHtml(__('Read %1', $title)) ?>">
+                        <span class="text-left"><?= $escaper->escapeHtml(__('Previous')) ?></span>
+                        <?= $escaper->escapeHtml($title) ?>
                     </a>
                 <?php } ?>
             </div>
@@ -37,10 +37,10 @@
                 <?php if ($nextPost) { ?>
                     <?php $title = $nextPost->getTitle() ?>
                     <a class="nextprev-link next-link float-right"
-                       href="<?= $block->escapeUrl($nextPost->getPostUrl()) ?>"
-                       title="<?= $block->escapeHtml(__('Read %1', $title)) ?>">
-                        <span class="text-right"><?= $block->escapeHtml(__('Next')) ?></span>
-                        <?= $block->escapeHtml($title) ?>
+                       href="<?= $escaper->escapeUrl($nextPost->getPostUrl()) ?>"
+                       title="<?= $escaper->escapeHtml(__('Read %1', $title)) ?>">
+                        <span class="text-right"><?= $escaper->escapeHtml(__('Next')) ?></span>
+                        <?= $escaper->escapeHtml($title) ?>
                     </a>
                 <?php } ?>
             </div>

--- a/view/frontend/templates/post/view/nextprev.phtml
+++ b/view/frontend/templates/post/view/nextprev.phtml
@@ -22,19 +22,19 @@
     <?php if ($prevPost || $nextPost) { ?>
         <div class="post-nextprev-hld clearfix">
             <?php if ($prevPost) { ?>
-                <?php $title = $block->escapeHtml($prevPost->getTitle()) ?>
+                <?php $title = $escaper->escapeHtml($prevPost->getTitle()) ?>
                 <a class="nextprev-link prev-link"
-                   href="<?= $block->escapeUrl($prevPost->getPostUrl()) ?>"
-                   title="<?= $block->escapeHtml(__('Read %1', $title)) ?>">
-                    <?= $block->escapeHtml(__('&larr; Previous')) ?>
+                   href="<?= $escaper->escapeUrl($prevPost->getPostUrl()) ?>"
+                   title="<?= $escaper->escapeHtml(__('Read %1', $title)) ?>">
+                    <?= $escaper->escapeHtml(__('&larr; Previous')) ?>
                 </a>
             <?php } ?>
             <?php if ($nextPost) { ?>
-                <?php $title = $block->escapeHtml($nextPost->getTitle()) ?>
+                <?php $title = $escaper->escapeHtml($nextPost->getTitle()) ?>
                 <a class="nextprev-link next-link"
-                   href="<?= $block->escapeUrl($nextPost->getPostUrl()) ?>"
-                   title="<?= $block->escapeHtml(__('Read %1', $title)) ?>">
-                    <?= $block->escapeHtml(__('Next &rarr;')) ?>
+                   href="<?= $escaper->escapeUrl($nextPost->getPostUrl()) ?>"
+                   title="<?= $escaper->escapeHtml(__('Read %1', $title)) ?>">
+                    <?= $escaper->escapeHtml(__('Next &rarr;')) ?>
                 </a>
             <?php } ?>
         </div>

--- a/view/frontend/templates/post/view/opengraph.phtml
+++ b/view/frontend/templates/post/view/opengraph.phtml
@@ -14,10 +14,10 @@
  */
 ?>
 
-<meta property="og:type" content="<?= $block->escapeHtml($block->getType()); ?>" />
-<meta property="og:title" content="<?= $block->escapeHtml($block->getTitle()); ?>" />
-<meta property="og:description" content="<?= $block->escapeHtml($block->getDescription()); ?>" />
-<meta property="og:url" content="<?= $block->escapeHtml($block->getPageUrl()); ?>" />
+<meta property="og:type" content="<?= $escaper->escapeHtml($block->getType()); ?>" />
+<meta property="og:title" content="<?= $escaper->escapeHtml($block->getTitle()); ?>" />
+<meta property="og:description" content="<?= $escaper->escapeHtml($block->getDescription()); ?>" />
+<meta property="og:url" content="<?= $escaper->escapeHtml($block->getPageUrl()); ?>" />
 <?php if ($image = $block->getImage()) { ?>
-<meta property="og:image" content="<?= $block->escapeHtml($image); ?>" />
+<meta property="og:image" content="<?= $escaper->escapeHtml($image); ?>" />
 <?php } ?>

--- a/view/frontend/templates/post/view/relatedposts.phtml
+++ b/view/frontend/templates/post/view/relatedposts.phtml
@@ -22,16 +22,16 @@
         <?php if (!$block->getHideTitle()) { ?>
         <div class="block-title title">
             <strong id="block-relatedposts-heading" role="heading" aria-level="2">
-                <?= $block->escapeHtml(__('Related Posts')) ?>
+                <?= $escaper->escapeHtml(__('Related Posts')) ?>
             </strong>
         </div>
         <?php } ?>
         <ol class="block-content">
             <?php foreach ($postCollection as $post) { ?>
                 <li class="item">
-                    <a class="post-item-link" title="<?= $block->escapeHtml($post->getTitle()) ?>"
-                       href="<?= $block->escapeUrl($post->getPostUrl()) ?>">
-                        <?= $block->escapeHtml($post->getTitle()) ?>
+                    <a class="post-item-link" title="<?= $escaper->escapeHtml($post->getTitle()) ?>"
+                       href="<?= $escaper->escapeUrl($post->getPostUrl()) ?>">
+                        <?= $escaper->escapeHtml($post->getTitle()) ?>
                     </a>
                 </li>
             <?php } ?>

--- a/view/frontend/templates/post/view/relatedproducts.phtml
+++ b/view/frontend/templates/post/view/relatedproducts.phtml
@@ -38,28 +38,28 @@ if ($exist = $block->getItems()->getSize()) {
 
     <?php if ($type == 'related' || $type == 'upsell'): ?>
         <?php if ($type == 'related'): ?>
-            <div class="mfblog-related-products-block block <?= $block->escapeHtml($class); ?>"
+            <div class="mfblog-related-products-block block <?= $escaper->escapeHtml($class); ?>"
                  data-mage-init='{"relatedProducts":{"relatedCheckbox":".related.checkbox"}}'
-                 data-limit="<?= $block->escapeHtml($limit); ?>"
-                 data-shuffle="<?= $block->escapeHtml($shuffle); ?>">
+                 data-limit="<?= $escaper->escapeHtml($limit); ?>"
+                 data-shuffle="<?= $escaper->escapeHtml($shuffle); ?>">
         <?php else: ?>
-            <div class="block <?= $block->escapeHtml($class); ?>"
+            <div class="block <?= $escaper->escapeHtml($class); ?>"
                  data-mage-init='{"upsellProducts":{}}'
-                 data-limit="<?= $block->escapeHtml($limit); ?>"
-                 data-shuffle="<?= $block->escapeHtml($shuffle); ?>">
+                 data-limit="<?= $escaper->escapeHtml($limit); ?>"
+                 data-shuffle="<?= $escaper->escapeHtml($shuffle); ?>">
         <?php endif; ?>
     <?php else: ?>
-        <div class="block <?= $block->escapeHtml($class); ?>">
+        <div class="block <?= $escaper->escapeHtml($class); ?>">
     <?php endif; ?>
     <div class="block-title title">
-        <strong id="block-<?= $block->escapeHtml($class)?>-heading"
+        <strong id="block-<?= $escaper->escapeHtml($class)?>-heading"
                 role="heading"
-                aria-level="2"><?= $block->escapeHtml($title); ?>
+                aria-level="2"><?= $escaper->escapeHtml($title); ?>
         </strong>
     </div>
-    <div class="block-content content" aria-labelledby="block-<?= $block->escapeHtml($class)?>-heading">
+    <div class="block-content content" aria-labelledby="block-<?= $escaper->escapeHtml($class)?>-heading">
 
-        <div class="products wrapper grid products-grid products-<?= $block->escapeHtml($type); ?>">
+        <div class="products wrapper grid products-grid products-<?= $escaper->escapeHtml($type); ?>">
             <ol class="products list items product-items">
                 <?php $iterator = 1; ?>
                 <?php foreach ($items as $_item): ?>
@@ -78,18 +78,18 @@ if ($exist = $block->getItems()->getSize()) {
                             '<li class="item product product-item">' :
                             '</li><li class="item product product-item">' ?>
                 <?php endif; ?>
-                <div class="product-item-info <?= $block->escapeHtml($available); ?>">
-                    <?= '<!-- ' . $block->escapeHtml($image) . '-->' ?>
-                    <a href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>"
+                <div class="product-item-info <?= $escaper->escapeHtml($available); ?>">
+                    <?= '<!-- ' . $escaper->escapeHtml($image) . '-->' ?>
+                    <a href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>"
                        class="product photo product-item-photo">
                         <?= $block->getImage($_item, $image)->toHtml(); ?>
                     </a>
                     <div class="product details product-item-details">
                         <strong class="product name product-item-name">
                             <a class="product-item-link"
-                               title="<?= $block->escapeHtml($_item->getName()) ?>"
-                               href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>">
-                            <?= $block->escapeHtml($_item->getName()) ?></a>
+                               title="<?= $escaper->escapeHtml($_item->getName()) ?>"
+                               href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>">
+                            <?= $escaper->escapeHtml($_item->getName()) ?></a>
                         </strong>
 
                         <?= /*@noEscape*/ $block->getProductPrice($_item); ?>
@@ -105,29 +105,29 @@ if ($exist = $block->getItems()->getSize()) {
                                             <?php if ($_item->isSaleable()): ?>
                                                 <?php if ($_item->getTypeInstance()->hasRequiredOptions($_item)): ?>
                                                     <button class="action tocart primary"
-                                                            data-mage-init='{"redirectUrl": {"url": "<?= $block->escapeUrl($block->getAddToCartUrl($_item)) ?>"}}'
+                                                            data-mage-init='{"redirectUrl": {"url": "<?= $escaper->escapeUrl($block->getAddToCartUrl($_item)) ?>"}}'
                                                             type="button"
-                                                            title="<?= $block->escapeHtml(__('Add to Cart')) ?>">
-                                                        <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                            title="<?= $escaper->escapeHtml(__('Add to Cart')) ?>">
+                                                        <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                     </button>
                                                 <?php else: ?>
                                                     <?php $postDataHelper = $this->helper(Magento\Framework\Data\Helper\PostHelper::class);
                                                             $postData = $postDataHelper->getPostData($block->getAddToCartUrl($_item), ['product' => $_item->getEntityId()]);
                                                     ?>
                                                     <button class="action tocart primary"
-                                                            data-post='<?= $block->escapeHtml($postData); ?>'
-                                                            type="button" title="<?= $block->escapeHtml(__('Add to Cart')) ?>">
-                                                        <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                            data-post='<?= $escaper->escapeHtml($postData); ?>'
+                                                            type="button" title="<?= $escaper->escapeHtml(__('Add to Cart')) ?>">
+                                                        <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                     </button>
                                                 <?php endif; ?>
                                             <?php else: ?>
                                                 <?php if ($_item->getIsSalable()): ?>
                                                     <div class="stock available">
-                                                        <span><?= $block->escapeHtml(__('In stock')) ?></span>
+                                                        <span><?= $escaper->escapeHtml(__('In stock')) ?></span>
                                                     </div>
                                                 <?php else: ?>
                                                     <div class="stock unavailable">
-                                                        <span><?= $block->escapeHtml(__('Out of stock')) ?></span>
+                                                        <span><?= $escaper->escapeHtml(__('Out of stock')) ?></span>
                                                     </div>
                                                 <?php endif; ?>
                                             <?php endif; ?>
@@ -138,11 +138,11 @@ if ($exist = $block->getItems()->getSize()) {
                                         <div class="secondary-addto-links actions-secondary" data-role="add-to-links">
                                             <?php if ($this->helper(Magento\Wishlist\Helper\Data::class)->isAllow() && $showWishlist): ?>
                                                 <a href="#"
-                                                   data-post='<?= $block->escapeHtml($block->getAddToWishlistParams($_item)); ?>'
+                                                   data-post='<?= $escaper->escapeHtml($block->getAddToWishlistParams($_item)); ?>'
                                                    class="action towishlist"
                                                    data-action="add-to-wishlist"
-                                                   title="<?= $block->escapeHtml(__('Add to Wish List')) ?>">
-                                                    <span><?= $block->escapeHtml(__('Add to Wish List')) ?></span>
+                                                   title="<?= $escaper->escapeHtml(__('Add to Wish List')) ?>">
+                                                    <span><?= $escaper->escapeHtml(__('Add to Wish List')) ?></span>
                                                 </a>
                                             <?php endif; ?>
                                             <?php if ($block->getAddToCompareUrl() && $showCompare): ?>
@@ -150,10 +150,10 @@ if ($exist = $block->getItems()->getSize()) {
                                                 $compareHelper = $this->helper(Magento\Catalog\Helper\Product\Compare::class);
                                                 ?>
                                                 <a href="#" class="action tocompare"
-                                                   data-post='<?= $block->escapeHtml($compareHelper->getPostDataParams($_item));?>'
+                                                   data-post='<?= $escaper->escapeHtml($compareHelper->getPostDataParams($_item));?>'
                                                    data-role="add-to-links"
-                                                   title="<?= $block->escapeHtml(__('Add to Compare')); ?>">
-                                                    <span><?= $block->escapeHtml(__('Add to Compare')) ?></span>
+                                                   title="<?= $escaper->escapeHtml(__('Add to Compare')); ?>">
+                                                    <span><?= $escaper->escapeHtml(__('Add to Compare')) ?></span>
                                                 </a>
                                             <?php endif; ?>
                                         </div>

--- a/view/frontend/templates/rss/feed.phtml
+++ b/view/frontend/templates/rss/feed.phtml
@@ -24,22 +24,22 @@ echo '<?xml version="1.0" encoding="UTF-8" ?>' . "\r\n";
      xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
      version="2.0" >
 <channel>
-   <title><?= $block->escapeHtml($block->getTitle()) ?></title>
-   <atom:link href="<?= $block->escapeUrl($block->getLink()) ?>" rel="self" type="application/rss+xml"/>
-   <link><?= $block->escapeUrl($block->getLink()) ?></link>
-   <description><?= $block->escapeHtml($block->getDescription()) ?></description>
+   <title><?= $escaper->escapeHtml($block->getTitle()) ?></title>
+   <atom:link href="<?= $escaper->escapeUrl($block->getLink()) ?>" rel="self" type="application/rss+xml"/>
+   <link><?= $escaper->escapeUrl($block->getLink()) ?></link>
+   <description><?= $escaper->escapeHtml($block->getDescription()) ?></description>
     <?php foreach ($_postCollection as $_post) { ?>
    <item>
-      <title><?= $block->escapeHtml($_post->getTitle()) ?></title>
-      <link><?= $block->escapeUrl($_post->getPostUrl()) ?></link>
-      <guid><?= $block->escapeUrl($_post->getPostUrl()) ?></guid>
+      <title><?= $escaper->escapeHtml($_post->getTitle()) ?></title>
+      <link><?= $escaper->escapeUrl($_post->getPostUrl()) ?></link>
+      <guid><?= $escaper->escapeUrl($_post->getPostUrl()) ?></guid>
       <description><![CDATA[<?= /*@noEscape*/ $block->getPostContent($_post) ?>]]></description>
         <?php /*if ($featuredImage = $_post->getFeaturedImage()) { ?>
          <image><?= $featuredImage ?></image>
       <?php }*/ ?>
-      <pubDate><?= $block->escapeHtml($_post->getPublishDate('r')) ?></pubDate>
+      <pubDate><?= $escaper->escapeHtml($_post->getPublishDate('r')) ?></pubDate>
         <?php foreach ($_post->getParentCategories() as $category) { ?>
-      <category><![CDATA[<?= $block->escapeHtml($category->getTitle()) ?>]]></category>
+      <category><![CDATA[<?= $escaper->escapeHtml($category->getTitle()) ?>]]></category>
         <?php } ?>
    </item>
     <?php } ?>

--- a/view/frontend/templates/sidebar/archive.phtml
+++ b/view/frontend/templates/sidebar/archive.phtml
@@ -20,7 +20,7 @@
 <?php if (count($_months)) { ?>
 <div class="widget block block-archive" data-bind="scope: 'blog-archive'">
     <div class="block-title">
-        <strong><?= $block->escapeHtml(__('Archive')) ?></strong>
+        <strong><?= $escaper->escapeHtml(__('Archive')) ?></strong>
     </div>
     <div class="block-content">
         <?php foreach ($_months as $time) { ?>
@@ -28,10 +28,10 @@
                 $title = $block->getTranslatedDate($time);
             ?>
             <div class="item">
-                <a title="<?= $block->escapeHtml(__('Archive %1', $title)) ?>"
+                <a title="<?= $escaper->escapeHtml(__('Archive %1', $title)) ?>"
                    class="archive-item-link"
-                   href="<?= $block->escapeUrl($block->getTimeUrl($time)) ?>">
-                    <?= $block->escapeHtml($title); ?>
+                   href="<?= $escaper->escapeUrl($block->getTimeUrl($time)) ?>">
+                    <?= $escaper->escapeHtml($title); ?>
                 </a>
             </div>
 

--- a/view/frontend/templates/sidebar/categories.phtml
+++ b/view/frontend/templates/sidebar/categories.phtml
@@ -19,7 +19,7 @@
 <?php if (count($items)) { ?>
     <div class="widget block block-categories" data-bind="scope: 'categories'">
         <div class="block-title">
-            <strong><?= $block->escapeHtml(__('Categories')) ?></strong>
+            <strong><?= $escaper->escapeHtml(__('Categories')) ?></strong>
         </div>
 
         <ul class="accordion"  id="accordion-2">
@@ -43,11 +43,11 @@
                 }
                 ?>
                 <li>
-                    <a title="<?= $block->escapeHtml($item->getTitle()) ?>" href="<?= $block->escapeUrl($item->getCategoryUrl()) ?>">
-                        <?= $block->escapeHtml($item->getTitle()) ?>
+                    <a title="<?= $escaper->escapeHtml($item->getTitle()) ?>" href="<?= $escaper->escapeUrl($item->getCategoryUrl()) ?>">
+                        <?= $escaper->escapeHtml($item->getTitle()) ?>
                     </a>
                     <?php if ($block->showPostsCount()) { ?>
-                        (<?= $block->escapeHtml($item->getPostsCount()) ?>)
+                        (<?= $escaper->escapeHtml($item->getPostsCount()) ?>)
                     <?php } ?>
                     <?php
                     $level = $newLevel;

--- a/view/frontend/templates/sidebar/post-related-products.phtml
+++ b/view/frontend/templates/sidebar/post-related-products.phtml
@@ -20,22 +20,22 @@ $image = 'product_thumbnail_image';
 ?>
 
 <?php if (count($items)) { ?>
-<div class="widget block block-<?= $block->escapeHtml(str_replace('_', '-', $block->getWidgetKey())) ?> block-list-posts" >
+<div class="widget block block-<?= $escaper->escapeHtml(str_replace('_', '-', $block->getWidgetKey())) ?> block-list-posts" >
     <div class="block-title">
-        <strong><?= $block->escapeHtml(__($block->getBlockTitle() ?: 'Related Products')) ?></strong>
+        <strong><?= $escaper->escapeHtml(__($block->getBlockTitle() ?: 'Related Products')) ?></strong>
     </div>
 
     <ol class="product-items">
         <?php foreach ($items as $_item) { ?>
         <li class="product-item">
             <div class="product-item-info" >
-                <a class="product-item-photo" href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>" title="<?= $block->escapeHtml($_item->getName()) ?>">
+                <a class="product-item-photo" href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>" title="<?= $escaper->escapeHtml($_item->getName()) ?>">
                     <?= $block->getImage($_item, $image)->toHtml(); ?>
                 </a>
                 <div class="product-item-details">
                     <strong class="product-item-name">
-                        <a class="product-item-link" href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>"  title="<?= $block->escapeHtml($_item->getName()) ?>">
-                            <span data-bind="text: product_name"><?= $block->escapeHtml($_item->getName()) ?></span>
+                        <a class="product-item-link" href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>"  title="<?= $escaper->escapeHtml($_item->getName()) ?>">
+                            <span data-bind="text: product_name"><?= $escaper->escapeHtml($_item->getName()) ?></span>
                         </a>
                     </strong>
                     <?= /*@noEscape*/ $block->getProductPrice($_item); ?>

--- a/view/frontend/templates/sidebar/recent.phtml
+++ b/view/frontend/templates/sidebar/recent.phtml
@@ -23,15 +23,15 @@
     $imageHelper = $this->helper(\Magefan\Blog\Helper\Image::class);
 ?>
 <?php if ($_postCollection->count()) { ?>
-<div class="widget block block-<?= $block->escapeHtml(str_replace('_', '-', $block->getWidgetKey())) ?> block-list-posts" >
+<div class="widget block block-<?= $escaper->escapeHtml(str_replace('_', '-', $block->getWidgetKey())) ?> block-list-posts" >
     <div class="block-title">
-        <strong><?= $block->escapeHtml(__($block->getBlockTitle() ?: 'Recent Posts')) ?></strong>
+        <strong><?= $escaper->escapeHtml(__($block->getBlockTitle() ?: 'Recent Posts')) ?></strong>
     </div>
     <div class="block-content">
         <?php foreach ($_postCollection as $_post) { ?>
             <?php
-                $_postUrl = $block->escapeUrl($_post->getPostUrl());
-                $_postName = $block->escapeHtml($_post->getTitle());
+                $_postUrl = $escaper->escapeUrl($_post->getPostUrl());
+                $_postName = $escaper->escapeHtml($_post->getTitle());
             ?>
             <div class="item clearfix">
                 <?php if ($block->getDisplayImage()) { ?>
@@ -51,8 +51,8 @@
                                     $featuredImageUrl = $this->getViewFileUrl('Magefan_Blog::images/default-no-image.png');
                                 }
                             ?>
-                            <img data-width-amp="<?= $width ?>" data-height-amp="<?= $height ?>" layout="responsive" src="<?= $block->escapeUrl($featuredImageUrl) ?>"
-                                 alt="<?= $block->escapeHtml($featuredImgAlt) ?>" />
+                            <img data-width-amp="<?= $width ?>" data-height-amp="<?= $height ?>" layout="responsive" src="<?= $escaper->escapeUrl($featuredImageUrl) ?>"
+                                 alt="<?= $escaper->escapeHtml($featuredImgAlt) ?>" />
                         </a>
                     </div>
                 <?php } ?>
@@ -63,7 +63,7 @@
 
                 <?php if ($block->getDisplayImage() && $_post->isPublishDateEnabled()) { ?>
                     <div class="post-item-date">
-                        <span class="value"><?= $block->escapeHtml($_post->getPublishDate()) ?></span>
+                        <span class="value"><?= $escaper->escapeHtml($_post->getPublishDate()) ?></span>
                     </div>
                 <?php } ?>
             </div>

--- a/view/frontend/templates/sidebar/rss.phtml
+++ b/view/frontend/templates/sidebar/rss.phtml
@@ -17,12 +17,12 @@
     <div class="block-title">
         <strong>
             <a target="_blank"
-               href="<?= $block->escapeUrl($block->getUrl('blog/rss/feed')) ?>">
-                <?= $block->escapeHtml(__('RSS Feed')) ?>
+               href="<?= $escaper->escapeUrl($block->getUrl('blog/rss/feed')) ?>">
+                <?= $escaper->escapeHtml(__('RSS Feed')) ?>
             </a>
         </strong>
         <img width="17" height="17" class="rss-icon"
-             src="<?= $block->escapeUrl($block->getViewFileUrl('Magefan_Blog::images/rss-icon.png')) ?>"
-             alt="<?= $block->escapeHtml(__('RSS Feed')) ?>" >
+             src="<?= $escaper->escapeUrl($block->getViewFileUrl('Magefan_Blog::images/rss-icon.png')) ?>"
+             alt="<?= $escaper->escapeHtml(__('RSS Feed')) ?>" >
     </div>
 </div>

--- a/view/frontend/templates/sidebar/search.phtml
+++ b/view/frontend/templates/sidebar/search.phtml
@@ -18,18 +18,18 @@
 <div class="widget block blog-search" data-bind="scope: 'blog-search'">
     <div class="block-content">
         <form class="form" id="blog_search_mini_form"
-              action="<?= $block->escapeUrl($block->getFormUrl()) ?>"
+              action="<?= $escaper->escapeUrl($block->getFormUrl()) ?>"
               method="get">
             <div class="field search">
                 <label class="label" for="blog_search">
-                    <span><?= $block->escapeHtml(__('Search')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Search')) ?></span>
                 </label>
                 <div class="control">
                     <input id="blog_search"
                            type="text"
                            name="q"
-                           value="<?= $block->escapeHtml($block->getQuery()) ?>"
-                           placeholder="<?= $block->escapeHtml(__('Search posts here...')) ?>"
+                           value="<?= $escaper->escapeHtml($block->getQuery()) ?>"
+                           placeholder="<?= $escaper->escapeHtml(__('Search posts here...')) ?>"
                            class="input-text"
                            maxlength="128" role="combobox"
                            aria-haspopup="false"
@@ -39,9 +39,9 @@
             </div>
             <div class="actions">
                 <button type="submit"
-                        title="<?= $block->escapeHtml(__('Search')) ?>"
+                        title="<?= $escaper->escapeHtml(__('Search')) ?>"
                         class="action search">
-                    <span><?= $block->escapeHtml(__('Search')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Search')) ?></span>
                 </button>
             </div>
         </form>

--- a/view/frontend/templates/sidebar/tag_claud.phtml
+++ b/view/frontend/templates/sidebar/tag_claud.phtml
@@ -18,15 +18,15 @@
 <?php if (count($tags)) { ?>
 <div class="widget block block-tagclaud" data-bind="scope: 'tagclaud'">
     <div class="block-title">
-        <strong><?= $block->escapeHtml(__('Tags')) ?></strong>
+        <strong><?= $escaper->escapeHtml(__('Tags')) ?></strong>
     </div>
 
     <div class="tagclaud-hld">
     <?php foreach ($tags as $tag) { ?>
         <?php $title = $tag->getTitle() ?>
-        <span class="<?= $block->escapeHtml($block->getTagClass($tag)) ?>">
-            <a href="<?= $block->escapeUrl($tag->getTagUrl()) ?>" title="<?= $block->escapeHtml($title) ?>">
-                <?= $block->escapeHtml($title) ?>
+        <span class="<?= $escaper->escapeHtml($block->getTagClass($tag)) ?>">
+            <a href="<?= $escaper->escapeUrl($tag->getTagUrl()) ?>" title="<?= $escaper->escapeHtml($title) ?>">
+                <?= $escaper->escapeHtml($title) ?>
             </a>
         </span>
     <?php } ?>

--- a/view/frontend/templates/sidebar/tag_claud_animated.phtml
+++ b/view/frontend/templates/sidebar/tag_claud_animated.phtml
@@ -19,17 +19,17 @@
 <?php if (count($tags)) { ?>
 <div class="widget block block-tagclaud" data-bind="scope: 'tagclaud'">
     <div class="block-title">
-        <strong><?= $block->escapeHtml(__('Tags')) ?></strong>
+        <strong><?= $escaper->escapeHtml(__('Tags')) ?></strong>
     </div>
 
     <div id="blogSidebarCloudCanvasContainer">
-        <canvas style="width:100%" height="<?= $block->escapeHtml($block->getConfigValue($block::CLOUD_HEIGHT)) ?>" id="blogSidebarCloudCanvas">
+        <canvas style="width:100%" height="<?= $escaper->escapeHtml($block->getConfigValue($block::CLOUD_HEIGHT)) ?>" id="blogSidebarCloudCanvas">
             <div class="tagclaud-hld">
                 <?php foreach ($tags as $tag) { ?>
                     <?php $title = $tag->getTitle() ?>
-                    <span class="<?= $block->escapeHtml($block->getTagClass($tag)) ?>">
-                        <a href="<?= $block->escapeUrl($tag->getTagUrl()) ?>" title="<?= $block->escapeHtml($title) ?>">
-                            <?= $block->escapeHtml($title) ?>
+                    <span class="<?= $escaper->escapeHtml($block->getTagClass($tag)) ?>">
+                        <a href="<?= $escaper->escapeUrl($tag->getTagUrl()) ?>" title="<?= $escaper->escapeHtml($title) ?>">
+                            <?= $escaper->escapeHtml($title) ?>
                          </a>
                     </span>
                 <?php } ?>

--- a/view/frontend/templates/themes/smartwave_porto/recent_home_custom.phtml
+++ b/view/frontend/templates/themes/smartwave_porto/recent_home_custom.phtml
@@ -26,7 +26,7 @@
       <h2 class="filterproduct-title"
           style="margin-top: 40px; padding-bottom: 5px;">
           <span class="content">
-              <strong><?= $block->escapeHtml($block->getTitle()) ?></strong>
+              <strong><?= $escaper->escapeHtml($block->getTitle()) ?></strong>
           </span>
           <span class="title_line"></span>
       </h2>
@@ -37,7 +37,7 @@
                     <?php
                         $postDate = $_post->getData("publish_time");
                         $_postUrl = $_post->getPostUrl();
-                        $_postName = $block->escapeHtml($_post->getTitle());
+                        $_postName = $escaper->escapeHtml($_post->getTitle());
                         $featuredImgAlt = $_post->getData('featured_list_img_alt') ?: $_post->getData('featured_img_alt');
                     if (!$featuredImgAlt) {
                         $featuredImgAlt = $_postName;
@@ -49,19 +49,19 @@
                         <div class="col-sm-5">
                            <div class="post-image">
                               <?php if ($post_image = $_post->getFeaturedImage()) { ?>
-                                <img src="<?= $block->escapeUrl($post_image); ?>" alt="<?= $block->escapeHtml($featuredImgAlt) ?>" />
+                                <img src="<?= $escaper->escapeUrl($post_image); ?>" alt="<?= $escaper->escapeHtml($featuredImgAlt) ?>" />
                                 <?php } ?>
                               <div class="post-date">
-                                <span class="day"><?= $block->escapeHtml(date("j", strtotime((string)$postDate))); ?></span>
-                                <span class="month"><?= $block->escapeHtml(date("M", strtotime((string)$postDate))); ?></span>
+                                <span class="day"><?= $escaper->escapeHtml(date("j", strtotime((string)$postDate))); ?></span>
+                                <span class="month"><?= $escaper->escapeHtml(date("M", strtotime((string)$postDate))); ?></span>
                               </div>
                            </div>
                         </div>
                         <div class="col-sm-7">
                            <div class="postTitle">
                               <h2>
-                                  <a href="<?= $block->escapeUrl($_post->getPostUrl()) ?>">
-                                      <?= $block->escapeHtml($_post->getTitle()) ?>
+                                  <a href="<?= $escaper->escapeUrl($_post->getPostUrl()) ?>">
+                                      <?= $escaper->escapeHtml($_post->getTitle()) ?>
                                   </a>
                               </h2>
                            </div>
@@ -69,8 +69,8 @@
                               <p><?= /*@noEscape*/ $_post->getShortFilteredContent() ?></p>
                            </div>
                            <a class="readmore"
-                              href="<?= $block->escapeUrl($_post->getPostUrl()) ?>">
-                               <?= $block->escapeHtml(__("Read more >"));?>
+                              href="<?= $escaper->escapeUrl($_post->getPostUrl()) ?>">
+                               <?= $escaper->escapeHtml(__("Read more >"));?>
                            </a>
                         </div>
                      </div>

--- a/view/frontend/templates/widget/porto_theme_recent_home.phtml
+++ b/view/frontend/templates/widget/porto_theme_recent_home.phtml
@@ -19,13 +19,13 @@
     $_postCollection = $block->getPostCollection();
 ?>
 <?php if ($_postCollection->count()) { ?>
-<h2 style="margin:0 0 18px 0;font-size:18px;font-weight:600;text-align:center" class="theme-color a-center"><?= $block->escapeHtml($block->getTitle()) ?></h2>
+<h2 style="margin:0 0 18px 0;font-size:18px;font-weight:600;text-align:center" class="theme-color a-center"><?= $escaper->escapeHtml($block->getTitle()) ?></h2>
 <div class="recent-posts">
     <div class="owl-carousel">
     <?php foreach ($_postCollection as $_post) { ?>
         <?php
-            $_postUrl = $block->escapeUrl($_post->getPostUrl());
-            $_postName = $block->escapeHtml($_post->getTitle());
+            $_postUrl = $escaper->escapeUrl($_post->getPostUrl());
+            $_postName = $escaper->escapeHtml($_post->getTitle());
         ?>
         <div class="item">
             <div class="row">
@@ -39,25 +39,25 @@
                                 $featuredImgAlt = $_postName;
                             }
                         ?>
-                           <img src="<?= $block->escapeHtml($featuredImage) ?>" alt="<?= $block->escapeHtml($featuredImgAlt) ?>" />
+                           <img src="<?= $escaper->escapeHtml($featuredImage) ?>" alt="<?= $escaper->escapeHtml($featuredImgAlt) ?>" />
                     <?php } ?>
                     </div>
                 </div>
                 <div class="col-md-7">
                     <div class="post-date">
-                        <span class="day"><?= $block->escapeHtml($_post->getPublishDate('j')) ?></span>
-                        <span class="month"><?= $block->escapeHtml($_post->getPublishDate('M')) ?></span>
+                        <span class="day"><?= $escaper->escapeHtml($_post->getPublishDate('j')) ?></span>
+                        <span class="month"><?= $escaper->escapeHtml($_post->getPublishDate('M')) ?></span>
                     </div>
                     <div class="postTitle">
                         <h2><a href="<?= $_postUrl ?>" ><?= $_postName ?></a></h2>
                     </div>
-                    <?php 
+                    <?php
                         $content = $block->getShorContent($_post);
                         $content = preg_replace("/<img[^>]+\>/i", "", $content);
                         $content = preg_replace("#<iframe[^>]+>.*?</iframe>#is", "", $content);
                     ?>
                     <div class="postContent"><?= /*@noEscape*/ $content ?></div>
-                    <a class="readmore" href="<?= $_postUrl ?>"><?= $block->escapeHtml(__('Read more &#187;')) ?></a>
+                    <a class="readmore" href="<?= $_postUrl ?>"><?= $escaper->escapeHtml(__('Read more &#187;')) ?></a>
                 </div>
             </div>
         </div>

--- a/view/frontend/templates/widget/recent.phtml
+++ b/view/frontend/templates/widget/recent.phtml
@@ -24,12 +24,12 @@ $imageHelper = $this->helper(\Magefan\Blog\Helper\Image::class);
 ?>
 <?php if ($_postCollection->count()) { ?>
 <div class="post-list-wrapper blog-widget-recent">
-    <h3 class="title"><?= $block->escapeHtml($block->getTitle()) ?></h3>
+    <h3 class="title"><?= $escaper->escapeHtml($block->getTitle()) ?></h3>
     <ul class="post-list clearfix">
         <?php foreach ($_postCollection as $_post) { ?>
             <?php
-                $_postUrl = $block->escapeUrl($_post->getPostUrl());
-                $_postName = $block->escapeHtml($_post->getTitle());
+                $_postUrl = $escaper->escapeUrl($_post->getPostUrl());
+                $_postName = $escaper->escapeHtml($_post->getTitle());
             ?>
             <li class="post-holder post-holder-<?= (int)$_post->getId() ?>">
                 <div class="post-header">
@@ -46,18 +46,18 @@ $imageHelper = $this->helper(\Magefan\Blog\Helper\Image::class);
                     <div class="post-info clear">
                         <?php if ($_post->isPublishDateEnabled()) { ?>
                             <div class="item post-posed-date">
-                                <span class="label"><?= $block->escapeHtml(__('Posted:')) ?></span>
-                                <span class="value"><?= $block->escapeHtml($_post->getPublishDate()) ?></span>
+                                <span class="label"><?= $escaper->escapeHtml(__('Posted:')) ?></span>
+                                <span class="value"><?= $escaper->escapeHtml($_post->getPublishDate()) ?></span>
                             </div>
                         <?php } ?>
                         <?php if ($_categoriesCount = $_post->getCategoriesCount()) { ?>
                         <div class="item post-categories">
-                            <span class="label"><?= $block->escapeHtml(__('Categories:')) ?></span>
+                            <span class="label"><?= $escaper->escapeHtml(__('Categories:')) ?></span>
                             <?php $n = 0;
                             foreach ($_post->getParentCategories() as $ct) { $n++; ?>
-                                <a title="<?= $block->escapeHtml($ct->getTitle()) ?>"
-                                   href="<?= $block->escapeUrl($ct->getCategoryUrl()) ?>">
-                                    <?= $block->escapeHtml($ct->getTitle()) ?>
+                                <a title="<?= $escaper->escapeHtml($ct->getTitle()) ?>"
+                                   href="<?= $escaper->escapeUrl($ct->getCategoryUrl()) ?>">
+                                    <?= $escaper->escapeHtml($ct->getTitle()) ?>
                                 </a>
                                 <?php if ($n != $_categoriesCount) { ?>, <?php } ?>
                             <?php } ?>
@@ -79,8 +79,8 @@ $imageHelper = $this->helper(\Magefan\Blog\Helper\Image::class);
                             ?>
                             <div class="post-ftimg-hld">
                                 <a href="<?= /*@noEscape*/ $_postUrl ?>" title="<?= /*@noEscape*/ $_postName ?>">
-                                    <img src="<?= $block->escapeHtml($featuredImage) ?>"
-                                         alt="<?= $block->escapeHtml($featuredImgAlt) ?>" />
+                                    <img src="<?= $escaper->escapeHtml($featuredImage) ?>"
+                                         alt="<?= $escaper->escapeHtml($featuredImgAlt) ?>" />
                                 </a>
                             </div>
                         <?php } ?>
@@ -91,7 +91,7 @@ $imageHelper = $this->helper(\Magefan\Blog\Helper\Image::class);
                            href="<?= /*@noEscape*/ $_postUrl ?>"
                            title="<?= /*@noEscape*/ $_postName ?>"
                            >
-                           <?= $block->escapeHtml(__('Read more &#187;')) ?>
+                           <?= $escaper->escapeHtml(__('Read more &#187;')) ?>
                         </a>
                     </div>
                 </div>

--- a/view/frontend/templates/widget/recent_masonry.phtml
+++ b/view/frontend/templates/widget/recent_masonry.phtml
@@ -25,12 +25,12 @@ $imageHelper = $this->helper(\Magefan\Blog\Helper\Image::class);
 ?>
 <?php if ($_postCollection->count()) { ?>
 <div class="post-list-wrapper blog-widget-recent blog-widget-recent-masonry">
-    <h3 class="title"><?= $block->escapeHtml($block->getTitle()) ?></h3>
+    <h3 class="title"><?= $escaper->escapeHtml($block->getTitle()) ?></h3>
     <ul class="post-list clearfix">
         <?php foreach ($_postCollection as $_post) { ?>
             <?php
-                $_postUrl = $block->escapeUrl($_post->getPostUrl());
-                $_postName = $block->escapeHtml($_post->getTitle());
+                $_postUrl = $escaper->escapeUrl($_post->getPostUrl());
+                $_postName = $escaper->escapeHtml($_post->getTitle());
             ?>
             <li class="post-holder post-holder-<?= (int)$_post->getId() ?>">
                 <div class="post-header">
@@ -47,18 +47,18 @@ $imageHelper = $this->helper(\Magefan\Blog\Helper\Image::class);
                     <div class="post-info clear">
                         <?php if ($_post->isPublishDateEnabled()) { ?>
                             <div class="item post-posed-date">
-                                <span class="label"><?= $block->escapeHtml(__('Posted:')) ?></span>
-                                <span class="value"><?= $block->escapeHtml($_post->getPublishDate()) ?></span>
+                                <span class="label"><?= $escaper->escapeHtml(__('Posted:')) ?></span>
+                                <span class="value"><?= $escaper->escapeHtml($_post->getPublishDate()) ?></span>
                             </div>
                         <?php } ?>
                         <?php if ($_categoriesCount = $_post->getCategoriesCount()) { ?>
                         <div class="item post-categories">
-                            <span class="label"><?= $block->escapeHtml(__('Categories:')) ?></span>
+                            <span class="label"><?= $escaper->escapeHtml(__('Categories:')) ?></span>
                             <?php $n = 0;
                             foreach ($_post->getParentCategories() as $ct) { $n++; ?>
-                                <a title="<?= $block->escapeHtml($ct->getTitle()) ?>"
-                                   href="<?= $block->escapeUrl($ct->getCategoryUrl()) ?>">
-                                    <?= $block->escapeHtml($ct->getTitle()) ?>
+                                <a title="<?= $escaper->escapeHtml($ct->getTitle()) ?>"
+                                   href="<?= $escaper->escapeUrl($ct->getCategoryUrl()) ?>">
+                                    <?= $escaper->escapeHtml($ct->getTitle()) ?>
                                 </a>
                                 <?php if ($n != $_categoriesCount) { ?>, <?php } ?>
                             <?php } ?>
@@ -80,8 +80,8 @@ $imageHelper = $this->helper(\Magefan\Blog\Helper\Image::class);
                             ?>
                             <div class="post-ftimg-hld">
                                 <a href="<?= /*@noEscape*/ $_postUrl ?>" title="<?= /*@noEscape*/ $_postName ?>">
-                                    <img src="<?= $block->escapeHtml($featuredImage) ?>"
-                                         alt="<?= $block->escapeHtml($featuredImgAlt) ?>" />
+                                    <img src="<?= $escaper->escapeHtml($featuredImage) ?>"
+                                         alt="<?= $escaper->escapeHtml($featuredImgAlt) ?>" />
                                 </a>
                             </div>
                         <?php } ?>
@@ -93,7 +93,7 @@ $imageHelper = $this->helper(\Magefan\Blog\Helper\Image::class);
                         <a class="post-read-more"
                            href="<?= /*@noEscape*/ $_postUrl ?>"
                            title="<?= /*@noEscape*/ $_postName ?>">
-                           <?= $block->escapeHtml(__('Read more &#187;')) ?>
+                           <?= $escaper->escapeHtml(__('Read more &#187;')) ?>
                         </a>
                     </div>
                 </div>
@@ -117,7 +117,7 @@ function( require, $, Masonry ) {
         })
     });
 });
-    
+
 "; ?>
 <?= /* @noEscape */ $mfSecureRenderer->renderTag('script', [], $script, false) ?>
 <?php /* more info http://masonry.desandro.com/extras.html */ ?>


### PR DESCRIPTION
Using escape methods on $block is deprecated via Magento2.Legacy.EscapeMethodsOnBlockClass. Ref.: https://github.com/magento/magento-coding-standard/blob/v33/Magento2/Sniffs/Legacy/EscapeMethodsOnBlockClassSniff.php

This PR fixes it.