### PR TITLE
Fixed 404 error when a post is accessed through a URL with different …

### DIFF
--- a/Model/ResourceModel/Post.php
+++ b/Model/ResourceModel/Post.php
@@ -412,7 +412,7 @@ class Post extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 
         $row = $this->getConnection()->fetchRow($select);
         if (isset($row['post_id']) && isset($row['identifier'])
-            && $row['identifier'] == $identifier) {
+            && strcasecmp($row['identifier'], $identifier) === 0) {
             return (string)$row['post_id'];
         }
 


### PR DESCRIPTION
…letter case

It could be argued that the URL should stay case-sensitive, although I believe Magento's routing system is case insensitive, so it would be best for this blog module to follow suit.

This might some more research though.