### PR TITLE
Amasty Xsearch module configuration cannot be opened due to TypeError

### DIFF
--- a/Plugin/Magento/Framework/View/Element/TemplatePlugin.php
+++ b/Plugin/Magento/Framework/View/Element/TemplatePlugin.php
@@ -37,7 +37,7 @@ class TemplatePlugin
     {
         if ('aminfotab.conflicts' === $subject->getNameInLayout() && $this->moduleManager->isEnabled('Amasty_Base')) {
             foreach ($conflictsMessages = $subject->getConflictsMessages() as $key => $conflictsMessage) {
-                if (strpos($conflictsMessage, 'Magefan')) {
+                if (strpos((string)$conflictsMessage, 'Magefan')) {
                     return '';
                 }
             }


### PR DESCRIPTION
This PR fixes the following error with PHP 8.4 and the `Amasty_Xsearch` module:
```
TypeError: strpos(): Argument #1 ($haystack) must be of type string, Magento\Framework\Phrase given in /var/www/html/vendor/magefan/module-blog/Plugin/Magento/Framework/View/Element/TemplatePlugin.php:41
Stack trace:
#0 /var/www/html/vendor/magefan/module-blog/Plugin/Magento/Framework/View/Element/TemplatePlugin.php(41): strpos(Object(Magento\Framework\Phrase), 'Magefan')
#1 /var/www/html/vendor/magento/framework/Interception/Interceptor.php(135): Magefan\Blog\Plugin\Magento\Framework\View\Element\TemplatePlugin->aroundGetTemplate(Object(Amasty\Base\Block\Adminhtml\System\Config\InformationBlocks\ExistingConflicts\Interceptor), Object(Closure))
#2 /var/www/html/vendor/magento/framework/Interception/Interceptor.php(153): Amasty\Base\Block\Adminhtml\System\Config\InformationBlocks\ExistingConflicts\Interceptor->{closure:Magento\Framework\Interception\Interceptor::___callPlugins():104}()
#3 /var/www/html/generated/code/Amasty/Base/Block/Adminhtml/System/Config/InformationBlocks/ExistingConflicts/Interceptor.php(50): Amasty\Base\Block\Adminhtml\System\Config\InformationBlocks\ExistingConflicts\Interceptor->___callPlugins('getTemplate', Array, NULL)
#4 /var/www/html/vendor/magento/framework/View/Element/Template.php(290): Amasty\Base\Block\Adminhtml\System\Config\InformationBlocks\ExistingConflicts\Interceptor->getTemplate()
#5 /var/www/html/vendor/magento/framework/View/Element/AbstractBlock.php(1128): Magento\Framework\View\Element\Template->_toHtml()
#6 /var/www/html/vendor/magento/framework/View/Element/AbstractBlock.php(1132): Magento\Framework\View\Element\AbstractBlock->{closure:Magento\Framework\View\Element\AbstractBlock::_loadCache():1122}()
#7 /var/www/html/vendor/magento/framework/View/Element/AbstractBlock.php(676): Magento\Framework\View\Element\AbstractBlock->_loadCache()
```